### PR TITLE
LTC highlight back to outline (vote on discord!)

### DIFF
--- a/server/fishtest/static/css/application.css
+++ b/server/fishtest/static/css/application.css
@@ -212,7 +212,7 @@ legend {
 }
 
 .ltc-highlight {
-  color: var(--bs-link-color);
+  outline: 1px solid var(--bs-link-color);
 }
 
 .time-odds {

--- a/server/fishtest/static/css/theme.dark.css
+++ b/server/fishtest/static/css/theme.dark.css
@@ -297,7 +297,7 @@ pre[style*="background-color: #66CCFF"] {
 }
 
 .ltc-highlight {
-  color: var(--bs-link-color) !important;
+  outline: 1px solid var(--bs-link-color) !important;
 }
 
 /* Darken pink border */


### PR DESCRIPTION
This is obviously somewhat contentious, being a subjective design and style choice.

My original intent was to keep it subtle and out of the way, so that those looking for it would find it, but that those *not* looking for it wouldn't be distracted by it. I felt some earlier iterations of this highlighting violated the second principle, hence the current form of subtle text coloring, but this current iteration was generally disliked on Discord.

Therefore, here is a small commit that switches back to using an outline, but on less elements than before, and with a thinner and overall less distracting form, in my opinion. Nevertheless, my opinion doesn't count more than anyone else's, so lets get more opinions.

Below in this message are sample images from my browser of the current and proposed version. Please vote for your preference. Thumbs up for the proposed outline version, thumbs down to keep the current text coloring. If prefer for right now to focus on this firm binary; if you prefer some third alternative, please still vote on the current two choices, but feel free to leave a message for future discussion/changes.

I assume it's better to vote on Discord than on Github, but whatever works. Here's the Discord voting link: https://discord.com/channels/435943710472011776/900771437177094156/1077938298900713502

Now the pictures:

Old/current style, using textcolor, if you prefer this, vote thumbs down:

![image](https://user-images.githubusercontent.com/6127392/220624175-78f28e27-d84d-44c4-8406-8f6ab39a2cf2.png)
 ![image](https://user-images.githubusercontent.com/6127392/220624089-c4ea1346-481b-4e10-bba6-4bf3f8ef462b.png)

Proposed style, using 1px outline, if you prefer this, vote thumbs up:

![image](https://user-images.githubusercontent.com/6127392/220624544-a5cefb0f-1fce-4220-845f-e22f40971fd7.png) 
![image](https://user-images.githubusercontent.com/6127392/220624811-7ee53378-097a-477e-b74e-36213e314318.png)