### PR TITLE
Save CPU on database backup

### DIFF
--- a/server/utils/backup.sh
+++ b/server/utils/backup.sh
@@ -4,18 +4,18 @@
 # List available backups with:
 # ${VENV}/bin/aws s3 ls s3://fishtest/backup/archive/
 # Download a backup with:
-# ${VENV}/bin/aws s3 cp s3://fishtest/backup/archive/<YYYYMMDD>/dump.tar dump.tar
+# ${VENV}/bin/aws s3 cp s3://fishtest/backup/archive/<YYYYMMDD>/dump.tar.gz dump.tar.gz
 
 # Load the variables with the AWS keys, cron uses a limited environment
 . ${HOME}/.profile
 
 cd ${HOME}/backup
 for db_name in "fishtest_new" "admin" "fishtest" "fishtest_testing"; do
-  mongodump --db=${db_name} --numParallelCollections=1 --excludeCollection="pgns" --gzip
+  mongodump --db=${db_name} --numParallelCollections=1 --excludeCollection="pgns"
 done
 tar -cvf dump.tar dump
 rm -rf dump
-
+pigz --fast dump.tar
 date_utc=$(date +%Y%m%d --utc)
 ${VENV}/bin/aws configure set default.s3.max_concurrent_requests 1
-${VENV}/bin/aws s3 cp dump.tar s3://fishtest/backup/archive/${date_utc}/dump.tar
+${VENV}/bin/aws s3 mv dump.tar.gz s3://fishtest/backup/archive/${date_utc}/dump.tar.gz


### PR DESCRIPTION
Dump first all files to one tar and then use multithreaded gzip (pigz) with fastest compression to save CPU as much as possible, then move the file to aws instead of copying it.

The "--gzip" parameter of mongodump uses gzip compression level 6 by default. In this patch we call mongodump without "--gzip" and then use `pigz` (multithreaded gzip) with compression level 1 (`--fast`) to save CPU time.

Please make sure that `pigz` is installed. On Ubunty, run 'apt install pigz`.