### PR TITLE
Serve gzip compressed data, when already available, without decompression

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -258,7 +258,7 @@ class RunDb:
         pgn = self.pgndb.find_one({"run_id": pgn_id})
         if pgn:
             response_body = pgn["pgn_zip"]
-            accept_encoding = request.headers.get("Accept-Encoding", "")
+            accept_encoding = self.request.headers.get("Accept-Encoding", "")
             if not "gzip" not in accept_encoding.lower():
                 return zlib.decompress(response_body).decode()
             # Some clients do not accept responses with the gzip encoding method.


### PR DESCRIPTION
Serve compressed data as is without decompression. Even if client does not support gzip compression, nginx can decompress it, saving valuable traffic and CPU cycles on the server application.

Some clients do not accept responses with the gzip encoding method. To serve such clients, add `gunzip on;` in nginx, see https://docs.nginx.com/nginx/admin-guide/web-server/compression/#enabling-decompression

1) add `application/x-chess-pgn` to `gzip_types`
2) add `gzip on;` and `gunzip on;`
