### PR TITLE
Don't acquire rundb.run_cache_lock when generating webpages

### DIFF
--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -1142,14 +1142,14 @@ def get_page_title(run):
 @view_config(route_name="tests_live_elo", renderer="tests_live_elo.mak")
 def tests_live_elo(request):
     run = request.rundb.get_run(request.matchdict["id"])
-    request.rundb.get_results(run)
+    request.rundb.get_results(run, save_run=False)
     return {"run": run, "page_title": get_page_title(run)}
 
 
 @view_config(route_name="tests_stats", renderer="tests_stats.mak")
 def tests_stats(request):
     run = request.rundb.get_run(request.matchdict["id"])
-    request.rundb.get_results(run)
+    request.rundb.get_results(run, save_run=False)
     return {"run": run, "page_title": get_page_title(run)}
 
 
@@ -1162,7 +1162,7 @@ def tests_view(request):
         follow = 0
     if run is None:
         raise exception_response(404)
-    results = request.rundb.get_results(run)
+    results = request.rundb.get_results(run, save_run=False)
     run["results_info"] = format_results(results, run)
     run_args = [("id", str(run["_id"]), "")]
     if run.get("rescheduled_from"):
@@ -1337,7 +1337,7 @@ def get_paginated_finished_runs(request):
     failed_runs = []
     for run in finished_runs:
         # Ensure finished runs have results_info
-        results = request.rundb.get_results(run)
+        results = request.rundb.get_results(run, save_run=False)
         if "results_info" not in run:
             run["results_info"] = format_results(results, run)
 


### PR DESCRIPTION
This lock is acquired every time we retrieve an individual run from the DB, so it's kind of an important lock.
    
On current master, while rendering the homepage, we might acquire and release this core lock dozens of times, once for each run,
and while acquired we prevent other threads from getting runs from the DB.
    
But we only do this while retrieving the run results, but we don't even need the lock to retrieve the results! It's just that
`rundb.get_results(run)` is used by both internal DB-updating code and by the webpage rendering code, and the former may need
to save its work with the lock, while rendering webpages is very much *not* an operation that writes to the DB -- no need to lock.
    
So instead we stick to "read-only mode", so to speak, which already exists, when using `rundb.get_results(run)` to render webpages.
And for the homepage in particular, we save dozens of acquire-release cycles, which could create myriad conflicts with other threads
... but no longer.
