### PR TITLE
Ensure that the homepage is properly refreshed when served from another instance

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -87,6 +87,7 @@ class RunDb:
         self.nndb = self.db["nns"]
         self.runs = self.db["runs"]
         self.deltas = self.db["deltas"]
+        self.comms = self.db["comms"]
         self.port = get_port()
         if self.port < 0:
             print(f"Unable to obtain the port number. Error: {self.port}", flush=True)


### PR DESCRIPTION
We add a db collection "comms" which currently contains one record {'type': 'ensure_refresh', 'timestamp': `<timestamp>`}. The function clear_hash() updates the timestamp.

The function check_db_refresh() may be used to verify if the timestamp of the last refresh is different from the timestamp in the comms collection.

If it is then a refresh should be performed.

Fixes https://github.com/glinscott/fishtest/pull/1606#issuecomment-1509706955 