### PR TITLE
Replace deprecated `datetime.datetime.utcnow()`

### DIFF
--- a/server/fishtest/actiondb.py
+++ b/server/fishtest/actiondb.py
@@ -267,7 +267,7 @@ class ActionDb:
             action["run_id"] = str(action["run_id"])
         ret = validate(schema, action, "action", strict=True)
         if ret == "":
-            action["time"] = datetime.utcnow().replace(tzinfo=timezone.utc).timestamp()
+            action["time"] = datetime.now(timezone.utc).timestamp()
             self.actions.insert_one(action)
         else:
             raise Exception("Validation failed with error '{}'".format(ret))

--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -1,6 +1,6 @@
 import base64
 import copy
-from datetime import datetime
+from datetime import datetime, timezone
 
 from fishtest.stats.stat_util import SPRT_elo
 from fishtest.util import optional_key, union, validate, worker_name
@@ -25,7 +25,7 @@ db directly. However this information may be slightly outdated, depending
 on how frequently the main instance flushes its run cache.
 """
 
-WORKER_VERSION = 212
+WORKER_VERSION = 213
 
 
 def validate_request(request):
@@ -126,7 +126,7 @@ class ApiView(object):
             raise exception(self.add_time({"error": error}))
 
     def validate_username_password(self, api):
-        self.__t0 = datetime.utcnow()
+        self.__t0 = datetime.now(timezone.utc)
         self.__api = api
         # is the request valid json?
         try:
@@ -191,7 +191,7 @@ class ApiView(object):
             self.__task = task
 
     def add_time(self, result):
-        result["duration"] = (datetime.utcnow() - self.__t0).total_seconds()
+        result["duration"] = (datetime.now(timezone.utc) - self.__t0).total_seconds()
         return result
 
     def get_username(self):
@@ -349,7 +349,7 @@ class ApiView(object):
 
     @view_config(route_name="api_calc_elo")
     def calc_elo(self):
-        self.__t0 = datetime.utcnow()
+        self.__t0 = datetime.now(timezone.utc)
         self.__api = "/api/calc_elo"
 
         W = self.request.params.get("W")
@@ -553,7 +553,7 @@ class ApiView(object):
         self.validate_request("/api/beat")
         run = self.run()
         task = self.task()
-        task["last_updated"] = datetime.utcnow()
+        task["last_updated"] = datetime.now(timezone.utc)
         self.request.rundb.buffer(run, False)
         return self.add_time({})
 

--- a/server/fishtest/userdb.py
+++ b/server/fishtest/userdb.py
@@ -1,7 +1,7 @@
 import sys
 import threading
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 from pymongo import ASCENDING
 
@@ -85,7 +85,7 @@ class UserDb:
                 {
                     "username": username,
                     "password": password,
-                    "registration_time": datetime.utcnow(),
+                    "registration_time": datetime.now(timezone.utc),
                     "blocked": True,
                     "email": email,
                     "groups": [],

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -2,7 +2,7 @@ import hashlib
 import math
 import re
 import smtplib
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from email.mime.text import MIMEText
 from functools import cache
 
@@ -425,8 +425,9 @@ def post_in_fishcooking_results(run):
 
 
 def diff_date(date):
-    if date != datetime.min:
-        diff = datetime.utcnow() - date
+    utc_date = date.replace(tzinfo=timezone.utc)
+    if utc_date != datetime.min.replace(tzinfo=timezone.utc):
+        diff = datetime.now(timezone.utc) - utc_date
     else:
         diff = timedelta.max
     return diff

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -1,8 +1,8 @@
 import base64
-import datetime
 import sys
 import unittest
 import zlib
+from datetime import datetime, timezone
 
 from fishtest.api import WORKER_VERSION, ApiView
 from pyramid.httpexceptions import HTTPUnauthorized
@@ -26,7 +26,7 @@ def new_run(self, add_tasks=0):
         "",
         username="travis",
         tests_repo="travis",
-        start_time=datetime.datetime.utcnow(),
+        start_time=datetime.now(timezone.utc),
     )
     run = self.rundb.get_run(run_id)
     run["approved"] = True

--- a/server/tests/test_rundb.py
+++ b/server/tests/test_rundb.py
@@ -1,6 +1,6 @@
-import datetime
 import sys
 import unittest
+from datetime import datetime, timezone
 
 import util
 from fishtest.api import WORKER_VERSION
@@ -64,7 +64,7 @@ class CreateRunDBTest(unittest.TestCase):
             "",
             username="travis",
             tests_repo="travis",
-            start_time=datetime.datetime.utcnow(),
+            start_time=datetime.now(timezone.utc),
         )
         run = self.rundb.get_run(run_id_stc)
         run["finished"] = True
@@ -92,7 +92,7 @@ class CreateRunDBTest(unittest.TestCase):
             "",
             username="travis",
             tests_repo="travis",
-            start_time=datetime.datetime.utcnow(),
+            start_time=datetime.now(timezone.utc),
         )
         print(" ")
         print(run_id)

--- a/server/tests/test_users.py
+++ b/server/tests/test_users.py
@@ -1,5 +1,5 @@
-import datetime
 import unittest
+from datetime import datetime, timezone
 
 import util
 from fishtest.views import login, signup
@@ -91,7 +91,7 @@ class Create90APITest(unittest.TestCase):
             "",
             username="travis",
             tests_repo="travis",
-            start_time=datetime.datetime.utcnow(),
+            start_time=datetime.now(timezone.utc),
         )
         self.rundb.userdb.user_cache.insert_one(
             {"username": "JoeUser", "cpu_hours": 12345}

--- a/server/utils/convert_actions.py
+++ b/server/utils/convert_actions.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timezone
 
 import pymongo
 from bson.objectid import ObjectId
@@ -10,19 +10,17 @@ if __name__ == "__main__":
     actions = actions_collection.find({}).sort("_id", 1)
     count = 0
     print("Starting conversion...")
-    t0 = datetime.datetime.utcnow()
+    t0 = datetime.now(timezone.utc)
     for action in actions:
         count += 1
         action_id = action["_id"]
-        if "time" in action and isinstance(action["time"], datetime.datetime):
-            action["time"] = (
-                action["time"].replace(tzinfo=datetime.timezone.utc).timestamp()
-            )
+        if "time" in action and isinstance(action["time"], datetime):
+            action["time"] = action["time"].replace(tzinfo=timezone.utc).timestamp()
         if "run_id" in action and isinstance(action["run_id"], ObjectId):
             action["run_id"] = str(action["run_id"])
         actions_collection.replace_one({"_id": action_id}, action)
         print("Actions converted: {}.".format(count), end="\r")
-    t1 = datetime.datetime.utcnow()
+    t1 = datetime.now(timezone.utc)
     duration = (t1 - t0).total_seconds()
     time_per_run = duration / count
     print("")

--- a/server/utils/purge_pgn.py
+++ b/server/utils/purge_pgn.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from fishtest.rundb import RunDb
 from pymongo import DESCENDING
@@ -9,7 +9,7 @@ from pymongo import DESCENDING
 def purge_pgn(rundb, finished, deleted, days):
     kept_runs, kept_tasks, kept_pgns = 0, 0, 0
     purged_runs, purged_tasks, purged_pgns = 0, 0, 0
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     cutoff_date_ltc = now - timedelta(days=5 * days)
     cutoff_date = now - timedelta(days=days)
     tc_regex = re.compile("^([2-9][0-9])|([1-9][0-9][0-9])")
@@ -23,8 +23,8 @@ def purge_pgn(rundb, finished, deleted, days):
             not deleted
             and finished
             and tc_regex.match(run["args"]["tc"])
-            and run["last_updated"] > cutoff_date_ltc
-        ) or run["last_updated"] > cutoff_date
+            and run["last_updated"].replace(tzinfo=timezone.utc) > cutoff_date_ltc
+        ) or run["last_updated"].replace(tzinfo=timezone.utc) > cutoff_date
 
         if keep:
             kept_runs += 1

--- a/server/utils/upgrade.py
+++ b/server/utils/upgrade.py
@@ -1,6 +1,6 @@
-import datetime
 import pprint
 import uuid
+from datetime import datetime, timezone
 
 import pymongo
 from fishtest.util import worker_name
@@ -40,8 +40,8 @@ run_default = {
         "priority": 0,
         "adjudication": True,
     },
-    "start_time": datetime.datetime.min,
-    "last_updated": datetime.datetime.min,
+    "start_time": datetime.min,
+    "last_updated": datetime.min,
     "tc_base": -1.0,
     "base_same_as_master": True,
     "results_stale": False,
@@ -105,7 +105,7 @@ if __name__ == "__main__":
     runs = runs_collection.find({}).sort("_id", 1)
     count = 0
     print("Starting conversion...")
-    t0 = datetime.datetime.utcnow()
+    t0 = datetime.now(timezone.utc)
     for r in runs:
         count += 1
         r_id = r["_id"]
@@ -113,7 +113,7 @@ if __name__ == "__main__":
         convert_task_list(r["tasks"])
         runs_collection.replace_one({"_id": r_id}, r)
         print("Runs converted: {}.".format(count), end="\r")
-    t1 = datetime.datetime.utcnow()
+    t1 = datetime.now(timezone.utc)
     duration = (t1 - t0).total_seconds()
     time_per_run = duration / count
     print("")

--- a/worker/games.py
+++ b/worker/games.py
@@ -1,6 +1,5 @@
 import copy
 import ctypes
-import datetime
 import hashlib
 import io
 import json
@@ -19,6 +18,7 @@ import threading
 import time
 from base64 import b64decode
 from contextlib import ExitStack
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from queue import Empty, Queue
 from zipfile import ZipFile
@@ -79,7 +79,7 @@ def log(s):
     logfile = Path(__file__).resolve().parent / LOGFILE
     with LOG_LOCK:
         with open(logfile, "a") as f:
-            f.write("{} : {}\n".format(datetime.datetime.utcnow(), s))
+            f.write("{} : {}\n".format(datetime.now(timezone.utc), s))
 
 
 def backup_log():
@@ -174,7 +174,7 @@ def requests_post(remote, *args, **kw):
 
 
 def send_api_post_request(api_url, payload, quiet=False):
-    t0 = datetime.datetime.utcnow()
+    t0 = datetime.now(timezone.utc)
     response = requests_post(
         api_url,
         data=json.dumps(payload),
@@ -204,7 +204,7 @@ def send_api_post_request(api_url, payload, quiet=False):
     if "error" in response:
         print("Error from remote: {}".format(response["error"]))
 
-    t1 = datetime.datetime.utcnow()
+    t1 = datetime.now(timezone.utc)
     w = 1000 * (t1 - t0).total_seconds()
     s = 1000 * response["duration"]
     log(
@@ -843,11 +843,11 @@ def parse_cutechess_output(
     t.daemon = True
     t.start()
 
-    end_time = datetime.datetime.utcnow() + datetime.timedelta(seconds=tc_limit)
+    end_time = datetime.now(timezone.utc) + timedelta(seconds=tc_limit)
     print("TC limit {} End time: {}".format(tc_limit, end_time))
 
     num_games_updated = 0
-    while datetime.datetime.utcnow() < end_time:
+    while datetime.now(timezone.utc) < end_time:
         try:
             line = q.get_nowait().strip()
         except Empty:
@@ -977,7 +977,7 @@ def parse_cutechess_output(
             update_pentanomial(line, rounds)
     else:
         raise WorkerException(
-            "{} is past end time {}".format(datetime.datetime.utcnow(), end_time)
+            "{} is past end time {}".format(datetime.now(timezone.utc), end_time)
         )
 
     return True

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 212, "updater.py": "JOyZ0qPEXaL82QdgajUzcNfhBbusBn8Fwcp3eGqeXfW1HpDWRD1jXDsrzVUaZeCd", "worker.py": "JNiGRpnjVNuplGzER45R9j24vlh1tugy+KV7ZFfrVEv5C9HT/RSTyZ0ocRrrNMyW", "games.py": "au3WiGyUAb26mcz5C2MhnU7rhe8X3JMEgnyUlo4aAH+dPjxnXCZrWh9xFjdNQoFZ"}
+{"__version": 213, "updater.py": "GEDqwD5F16roa/hRFbTNbbUqW/smvbe/4Rcf09O5BIJOAI63wsAVgLEnMtQp1naZ", "worker.py": "dT4tz1DqISrMUZhqlQNV94nvpf6EPVg0ebs118cSJ8gC7C22PetaQjQgA1Ciupm4", "games.py": "LyUiwCAMXllQWLIHsWGZpQpziYGO6dK3jDXzimEFd2ehLLrp5nsSGbl7+AUQTnAa"}

--- a/worker/updater.py
+++ b/worker/updater.py
@@ -1,7 +1,7 @@
-import datetime
 import os
 import shutil
 import sys
+from datetime import datetime, timezone
 from distutils.dir_util import copy_tree
 from pathlib import Path
 from zipfile import ZipFile
@@ -68,7 +68,7 @@ def update(restart=True, test=False):
     os.chdir(worker_dir)
     testing_dir = worker_dir / "testing"
     if testing_dir.exists():
-        time_stamp = str(datetime.datetime.timestamp(datetime.datetime.utcnow()))
+        time_stamp = str(datetime.now(timezone.utc).timestamp())
         bkp_testing_dir = worker_dir / ("_testing_" + time_stamp)
         testing_dir.replace(bkp_testing_dir)
         testing_dir.mkdir()

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import atexit
 import base64
-import datetime
 import getpass
 import hashlib
 import json
@@ -23,6 +22,7 @@ import zlib
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 from configparser import ConfigParser
 from contextlib import ExitStack
+from datetime import datetime, timezone
 from functools import partial
 from pathlib import Path
 
@@ -54,7 +54,7 @@ from updater import update
 # Several packages are called "expression".
 # So we make sure to use the locally installed one.
 
-WORKER_VERSION = 212
+WORKER_VERSION = 213
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0
@@ -1329,7 +1329,7 @@ def fetch_and_handle_task(
     # Print the current time for log purposes
     print(
         "Current time is {} UTC (local offset: {}) ".format(
-            datetime.datetime.utcnow(), utcoffset()
+            datetime.now(timezone.utc), utcoffset()
         )
     )
 


### PR DESCRIPTION
The function is deprecated in python 3.12, see
https://docs.python.org/3.12/library/datetime.html?highlight=utcnow#datetime.datetime.now

"Because naive datetime objects are treated by many datetime methods as local times, it is preferred to use aware datetimes to represent times in UTC. As such, the recommended way to create an object representing the current time in UTC is by calling `datetime.now(timezone.utc)`."