### PR TITLE
Replace deprecated `distutils` package

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -25,7 +25,7 @@ db directly. However this information may be slightly outdated, depending
 on how frequently the main instance flushes its run cache.
 """
 
-WORKER_VERSION = 213
+WORKER_VERSION = 214
 
 
 def validate_request(request):

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 213, "updater.py": "GEDqwD5F16roa/hRFbTNbbUqW/smvbe/4Rcf09O5BIJOAI63wsAVgLEnMtQp1naZ", "worker.py": "dT4tz1DqISrMUZhqlQNV94nvpf6EPVg0ebs118cSJ8gC7C22PetaQjQgA1Ciupm4", "games.py": "LyUiwCAMXllQWLIHsWGZpQpziYGO6dK3jDXzimEFd2ehLLrp5nsSGbl7+AUQTnAa"}
+{"__version": 214, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "DAMoJ5Rh2a7U8hqA9LX1zba0o8uvrGQVfF+6vcs32SnUDhYen9VYajljx6mzFhAn", "games.py": "LyUiwCAMXllQWLIHsWGZpQpziYGO6dK3jDXzimEFd2ehLLrp5nsSGbl7+AUQTnAa"}

--- a/worker/updater.py
+++ b/worker/updater.py
@@ -1,8 +1,8 @@
 import os
 import shutil
 import sys
+import tempfile
 from datetime import datetime, timezone
-from distutils.dir_util import copy_tree
 from pathlib import Path
 from zipfile import ZipFile
 
@@ -26,12 +26,24 @@ def do_restart():
 
 def update(restart=True, test=False):
     worker_dir = Path(__file__).resolve().parent
-    update_dir = worker_dir / "update"
-    update_dir.mkdir(exist_ok=True)
-
+    update_dir = Path(tempfile.mkdtemp(dir=worker_dir))
     worker_zip = update_dir / "wk.zip"
-    with open(worker_zip, "wb+") as f:
-        f.write(requests.get(WORKER_URL).content)
+
+    try:
+        response = requests.get(WORKER_URL)
+        response.raise_for_status()
+    except Exception as e:
+        print(
+            "Failed to download {}:\n".format(WORKER_URL),
+            e,
+            sep="",
+            file=sys.stderr,
+        )
+        shutil.rmtree(update_dir)
+        return None
+    else:
+        with open(worker_zip, "wb+") as f:
+            f.write(response.content)
 
     with ZipFile(worker_zip) as zip_file:
         zip_file.extractall(update_dir)
@@ -57,7 +69,13 @@ def update(restart=True, test=False):
                     sep="",
                     file=sys.stderr,
                 )
-        copy_tree(str(worker_src), str(worker_dir))
+        if sys.version_info < (3, 8):
+            from distutils.dir_util import copy_tree
+
+            copy_tree(str(worker_src), str(worker_dir))
+        else:
+            shutil.copytree(worker_src, worker_dir, dirs_exist_ok=True)
+
     else:
         file_list = os.listdir(worker_src)
     shutil.rmtree(update_dir)

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -54,7 +54,7 @@ from updater import update
 # Several packages are called "expression".
 # So we make sure to use the locally installed one.
 
-WORKER_VERSION = 213
+WORKER_VERSION = 214
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0


### PR DESCRIPTION
The package `distutils` is deprecated since python 3.10 and it is scheduled to be removed with python 3.12, see: https://docs.python.org/3.12/whatsnew/3.12.html
https://github.com/python/cpython/issues/92584

`shutil.copytree()` is able to copy the source directory tree to an existing destination directory only from python 3.8 (parameter `dirs_exist_ok=True`), for python < 3.8 still use `distutils.dir_util.copy_tree()`

While here:
- create in a safe way the temporary directory used for the update
- deal with possible download problems

Raise worker version to 214 (also server side)