### PR TITLE
send full commit SHAs to cutechess-cli

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-# List of authors for fishtest, as of April 12, 2023
+# List of authors for fishtest, as of August 31, 2023
 
 Gary Linscott (glinscott)
 
@@ -37,6 +37,7 @@ Noé Costa
 Onur Zungur (zungur)
 Pasquale Pigazzini (ppigazzini)
 Raimund Heid (RaimundHeid)
+Robert Nürnberg (robertnurnberg)
 Ronald de Man (syzygy1)
 Sebastian Buchwald (UniQP)
 sf-x

--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -25,7 +25,7 @@ db directly. However this information may be slightly outdated, depending
 on how frequently the main instance flushes its run cache.
 """
 
-WORKER_VERSION = 214
+WORKER_VERSION = 215
 
 
 def validate_request(request):

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 214, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "DAMoJ5Rh2a7U8hqA9LX1zba0o8uvrGQVfF+6vcs32SnUDhYen9VYajljx6mzFhAn", "games.py": "LyUiwCAMXllQWLIHsWGZpQpziYGO6dK3jDXzimEFd2ehLLrp5nsSGbl7+AUQTnAa"}
+{"__version": 215, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "AoPX3L3sjfzj1XpHlkbOHO1ZXm9XFO46O/kXVl6wB7G0HoVNsHt1ThBMjoZ1mw30", "games.py": "APqS6APFNgKvbL16HuJFsGOGf3qH9TfpTy4iyOFC0X6FhfsAwCSzEEnFyM8leaW4"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -54,7 +54,7 @@ from updater import update
 # Several packages are called "expression".
 # So we make sure to use the locally installed one.
 
-WORKER_VERSION = 214
+WORKER_VERSION = 215
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0


### PR DESCRIPTION
This PR uses the full commit sha of `Base` for the engine name sent to cutechess-cli.

This would make it easier for scripts to identify the SF version that played games on fishtest.

Possible applications would be the tracking of the normalizing constant in SF's WDL_model, in the spirit of @vondele 's matetrack.

I do not know if the longer names could break things for other third party tools that make use of fishtest pgn's, so feedback would be appreciated.