### PR TITLE
Update book to UHO_4060_v3

### DIFF
--- a/server/fishtest/static/js/spsa_new.js
+++ b/server/fishtest/static/js/spsa_new.js
@@ -95,7 +95,7 @@ function spsa_compute(spsa_setup) {
 /*
 Below is some code to estimate the draw ratio from the time
 control. The algorithm is very naive. It uses interpolation for
-a few data points valid for the book "UHO_4060_v2.epd".
+a few data points valid for the book "UHO_4060_v3.epd".
 */
 
 function tc_to_seconds(tc) {
@@ -153,7 +153,7 @@ function logistic(x) {
 
 function draw_ratio(tc) {
   /*
-  Formula approximately valid for the book "UHO_4060_v2.epd".
+  Formula approximately valid for the book "UHO_4060_v3.epd".
   The "virtual" draw ratio of an unbalanced book is defined as
   1 - 4 * ("pentanomial variance/game")
   */

--- a/server/fishtest/templates/tests_run.mak
+++ b/server/fishtest/templates/tests_run.mak
@@ -4,8 +4,8 @@
   from fishtest.util import format_bounds
   elo_model = "normalized"
   fb = lambda e0, e1: format_bounds(elo_model, e0, e1)
-  test_book = "UHO_4060_v2.epd"
-  pt_book = "UHO_4060_v2.epd"
+  test_book = "UHO_4060_v3.epd"
+  pt_book = "UHO_4060_v3.epd"
 %>
 <%
   base_branch = args.get('base_tag', 'master')
@@ -476,7 +476,7 @@
                         <a href="https://github.com/vdbergh/spsa_simul" target="_blank">
                           https://github.com/vdbergh/spsa_simul</a
                         >. Currently this option should be used with the book
-                        'UHO_4060_v2.epd' and in addition the option should not be used with
+                        'UHO_4060_v3.epd' and in addition the option should not be used with
                         nodestime or with more than one thread.
                       </div>
                     </div>

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -371,7 +371,7 @@ def remaining_hours(run):
         if llr >= llr_bound:
             return 0
 
-        # Assume all tests use default book (UHO_4060_v2).
+        # Assume all tests use default book (UHO_4060_v3).
         book_positions = 242201
         t = scipy.stats.beta(1, 15).cdf(min(N / book_positions, 1.0))
         expected_games_llr = int(2 * N * llr_bound / llr)


### PR DESCRIPTION
this book adds back the move counters to UHO_4060_v2, restored from UHO_4060_v1, but is otherwise identical.