### PR TITLE
Various validation fixes.

### DIFF
--- a/server/fishtest/userdb.py
+++ b/server/fishtest/userdb.py
@@ -3,10 +3,12 @@ import threading
 import time
 from datetime import datetime, timezone
 
+from bson.objectid import ObjectId
 from fishtest.util import optional_key, validate
 from pymongo import ASCENDING
 
 schema = {
+    optional_key("_id"): ObjectId,
     "username": str,
     "password": str,
     "registration_time": datetime,
@@ -14,7 +16,7 @@ schema = {
     "email": str,
     "groups": list,
     "tests_repo": str,
-    optional_key("machine_limit"): int,
+    "machine_limit": int,
 }
 
 DEFAULT_MACHINE_LIMIT = 16
@@ -87,7 +89,7 @@ class UserDb:
     def add_user_group(self, username, group):
         user = self.find(username)
         user["groups"].append(group)
-        assert validate(schema, user, "user", strict=False) == ""
+        assert validate(schema, user, "user", strict=True) == ""
         self.users.replace_one({"_id": user["_id"]}, user)
         self.clear_cache()
 
@@ -106,7 +108,7 @@ class UserDb:
                 "tests_repo": "",
                 "machine_limit": DEFAULT_MACHINE_LIMIT,
             }
-            assert validate(schema, user, "user", strict=False) == ""
+            assert validate(schema, user, "user", strict=True) == ""
             self.users.insert_one(user)
             self.last_pending_time = 0
 
@@ -115,7 +117,7 @@ class UserDb:
             return False
 
     def save_user(self, user):
-        assert validate(schema, user, "user", strict=False) == ""
+        assert validate(schema, user, "user", strict=True) == ""
         self.users.replace_one({"_id": user["_id"]}, user)
         self.last_pending_time = 0
         self.clear_cache()

--- a/server/tests/test_validate.py
+++ b/server/tests/test_validate.py
@@ -1,0 +1,97 @@
+import unittest
+
+from fishtest.util import _keys, optional_key, union, validate
+
+
+class TestValidation(unittest.TestCase):
+    def test_keys(self):
+        schema = {optional_key("a"): 1, "b": 2, optional_key("c"): 3}
+        keys = _keys(schema)
+        self.assertEqual(keys, {"a", "b", "c"})
+
+    def test_strict(self):
+        schema = {optional_key("a"): 1, "b": 2}
+        name = "my_object"
+        object = {"b": 2, "c": 3}
+        valid = validate(schema, object, name, strict=True)
+        self.assertFalse(valid == "")
+
+        object = {"a": 1, "c": 3}
+        valid = validate(schema, object, name, strict=True)
+        self.assertFalse(valid == "")
+
+        object = {"a": 1, "b": 2}
+        valid = validate(schema, object, name, strict=True)
+        self.assertTrue(valid == "")
+
+        object = {"b": 2}
+        valid = validate(schema, object, name, strict=True)
+        self.assertTrue(valid == "")
+
+    def test_missing_keys(self):
+        schema = {optional_key("a"): 1, "b": 2}
+        name = "my_object"
+        object = {"b": 2, "c": 3}
+        valid = validate(schema, object, name, strict=False)
+        self.assertTrue(valid == "")
+
+        object = {"a": 1, "c": 3}
+        valid = validate(schema, object, name, strict=False)
+        self.assertFalse(valid == "")
+
+        object = {"a": 1, "b": 2}
+        valid = validate(schema, object, name, strict=False)
+        self.assertTrue(valid == "")
+
+        object = {"b": 2}
+        valid = validate(schema, object, name, strict=False)
+        self.assertTrue(valid == "")
+
+    def test_union(self):
+        schema = {optional_key("a"): 1, "b": union(2, 3)}
+        name = "my_object"
+        object = {"b": 2, "c": 3}
+        valid = validate(schema, object, name, strict=False)
+        self.assertTrue(valid == "")
+
+        object = {"b": 4, "c": 3}
+        valid = validate(schema, object, name, strict=False)
+        self.assertFalse(valid == "")
+
+    def test_validate(self):
+        class lower_case_string:
+            @staticmethod
+            def __validate__(object, name, strict=False):
+                if not isinstance(object, str):
+                    return f"{name} is not a string"
+                for c in object:
+                    if not ("a" <= c <= "z"):
+                        return f"{c}, contained in the string {name}, is not a lower case letter"
+                return ""
+
+        schema = lower_case_string
+        object = 1
+        name = "my_object"
+        valid = validate(schema, object, name, strict=True)
+        self.assertFalse(valid == "")
+
+        object = "aA"
+        valid = validate(schema, object, name, strict=True)
+        self.assertFalse(valid == "")
+
+        object = "ab"
+        valid = validate(schema, object, name, strict=True)
+        self.assertTrue(valid == "")
+
+        schema = {"a": lower_case_string}
+        object = {"a": "ab"}
+        valid = validate(schema, object, name, strict=True)
+        self.assertTrue(valid == "")
+
+        object = {"a": "AA"}
+        valid = validate(schema, object, name, strict=True)
+        self.assertFalse(valid == "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Use f-strings in `validate()`.
- Fix bug which prevented strict validation with optional keys.
- Tighten up the user schema and use strict validation (strict validation means that one cannot introduce keys which are not in the schema).
- Add some unittests for the validation code. There is in particular a test that shows how to create a type `lower_case_string`.