### PR TITLE
Merge cutechess-cli stdout and stderr inside the worker instead of relying on Python to do it

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -25,7 +25,7 @@ db directly. However this information may be slightly outdated, depending
 on how frequently the main instance flushes its run cache.
 """
 
-WORKER_VERSION = 218
+WORKER_VERSION = 219
 
 
 def validate_request(request):

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 218, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "JTcLpyoueO7A/L7xaZVhPowKXwqXzIcQL615cc0Gm+bwbefz9hUNuIUyUD+pL8is", "games.py": "jvH/ezkXwWUtTniX0jbqhAsNWqn0BNkHtJZ6PK85HXBGwDdmPrVgfaPAUPN4Us9r"}
+{"__version": 219, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "AkTSAxyuMfhvsRYKcQUVpykSFVDNtwsbH49/RPmv9CNjt8IwReaKshMsiZ4ugy6g", "games.py": "I+cktT3rD/gXlFYHmQpT8GHBfqR8VIjI4c6NHM68rn9gJJL/xu9AsOSLZys71s38"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -54,7 +54,7 @@ from updater import update
 # Several packages are called "expression".
 # So we make sure to use the locally installed one.
 
-WORKER_VERSION = 218
+WORKER_VERSION = 219
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0


### PR DESCRIPTION
See the comments for #1815 .

This PR seems to work fine when the only messages are on stdout. Not tested yet when there are actually error messages. 

One way to do it is to create a test with an option unknown to SF.