### PR TITLE
Implement efficient PGN upload and bulk download

### DIFF
--- a/server/fishtest/__init__.py
+++ b/server/fishtest/__init__.py
@@ -116,7 +116,7 @@ def main(global_config, **settings):
     config.add_route("api_get_task", "/api/get_task/{id}/{task_id}")
     config.add_route("api_upload_pgn", "/api/upload_pgn")
     config.add_route("api_download_pgn", "/api/pgn/{id}")
-    config.add_route("api_download_pgn_100", "/api/pgn_100/{skip}")
+    config.add_route("api_download_run_pgns", "/api/run_pgns/{id}")
     config.add_route("api_download_nn", "/api/nn/{id}")
     config.add_route("api_get_elo", "/api/get_elo/{id}")
     config.add_route("api_actions", "/api/actions")

--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -482,14 +482,14 @@ class ApiView(object):
         )
         return self.add_time(result)
 
-    def download_archive(self, archive_name, archive):
-        if archive:
+    def download_archive(self, zip_name, zip_buffer):
+        if zip_buffer:
             response = Response(content_type="application/zip")
-            response.app_iter = archive
-            response.content_length = archive.getbuffer().nbytes
+            response.app_iter = zip_buffer
+            response.content_length = zip_buffer.getbuffer().nbytes
             response.headers[
                 "Content-Disposition"
-            ] = f'attachment; filename="{archive_name}"'
+            ] = f'attachment; filename="{zip_name}"'
             return response
         else:
             return Response("No data found", status=404)
@@ -498,14 +498,14 @@ class ApiView(object):
     def download_pgn(self):
         pgn_zip = self.request.matchdict["id"]
         run_id = pgn_zip.split(".")[0]  # strip .pgn.zip
-        archive = self.request.rundb.get_pgn(run_id)
-        return self.download_archive(pgn_zip, archive)
+        zip_buffer = self.request.rundb.get_pgn(run_id)
+        return self.download_archive(pgn_zip, zip_buffer)
 
     @view_config(route_name="api_download_run_pgns")
     def download_run_pgns(self):
         run_id = self.request.matchdict["id"]
-        archive = self.request.rundb.get_run_pgns(run_id)
-        return self.download_archive(f"{run_id}_pgns.zip", archive)
+        zip_buffer = self.request.rundb.get_run_pgns(run_id)
+        return self.download_archive(f"{run_id}_pgns.zip", zip_buffer)
 
     @view_config(route_name="api_download_nn")
     def download_nn(self):

--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -262,7 +262,9 @@ class RunDb:
     def get_pgn(self, run_id):
         pgn = self.pgndb.find_one({"run_id": run_id})
         if pgn:
-            zip_buffer = io.BytesIO(pgn["pgn_zip"])
+            pgn_zip = pgn["pgn_zip"]
+            pgn_zip = self.force_to_zip(run_id, pgn_zip)
+            zip_buffer = io.BytesIO(pgn_zip)
             zip_buffer.seek(0)
             return zip_buffer
         return None
@@ -274,7 +276,9 @@ class RunDb:
             zip_buffer = io.BytesIO()
             with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_STORED) as zipf:
                 for pgn in pgns:
-                    zipf.writestr(f"{pgn['run_id']}.pgn.zip", pgn["pgn_zip"])
+                    pgn_zip = pgn["pgn_zip"]
+                    pgn_zip = self.force_to_zip(run_id, pgn_zip)
+                    zipf.writestr(f"{pgn['run_id']}.pgn.zip", pgn_zip)
             zip_buffer.seek(0)
             return zip_buffer
         return None

--- a/server/fishtest/templates/tasks.mak
+++ b/server/fishtest/templates/tasks.mak
@@ -22,7 +22,7 @@
   %>
   <tr class="${active_style}" id=task${task_id}>
     <td>
-      <a href=${f"/api/pgn/{run['_id']}-{task_id:d}.pgn"}>${task_id}</a>
+      <a href=${f"/api/pgn/{run['_id']}-{task_id:d}.pgn.zip"}>${task_id}</a>
     </td>
     % if 'bad' in task:
       <td style="text-decoration:line-through; background-color:#ffebeb">

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -378,23 +378,23 @@ class TestApi(unittest.TestCase):
         run_id = new_run(self, add_tasks=1)
         task_id = 0
         pgn_text = "1. e4 e5 2. d4 d5"
-        zip_buffer = io.BytesIO()
-        with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zipf:
-            zipf.writestr(f"{run_id}-{task_id}.pgn", pgn_text)
-        request = self.correct_password_request(
-            {
-                "run_id": run_id,
-                "task_id": task_id,
-                "pgn": base64.b64encode(zip_buffer.getvalue()).decode(),
-            }
-        )
+        with io.BytesIO() as zip_buffer:
+            with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zipf:
+                zipf.writestr(f"{run_id}-{task_id}.pgn", pgn_text)
+            request = self.correct_password_request(
+                {
+                    "run_id": run_id,
+                    "task_id": task_id,
+                    "pgn": base64.b64encode(zip_buffer.getvalue()).decode(),
+                }
+            )
         response = ApiView(request).upload_pgn()
         response.pop("duration", None)
         self.assertTrue(response == {})
 
         pgn_filename_prefix = "{}-{}".format(run_id, task_id)
         zip_pgn = self.rundb.get_pgn(pgn_filename_prefix)
-        with zipfile.ZipFile(zip_pgn) as zipf:
+        with zipfile.ZipFile(io.BytesIO(zip_pgn), "r") as zipf:
             file_name = zipf.namelist()[0]
             pgn = zipf.read(file_name).decode()
         self.assertEqual(pgn, pgn_text)

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 220, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "zMpxJoKT+iIxoYN7YYRqWanhc+R+/pN+y7bZL2zySO9EOIePf7LDQLbQbX2DpD7l", "games.py": "I+cktT3rD/gXlFYHmQpT8GHBfqR8VIjI4c6NHM68rn9gJJL/xu9AsOSLZys71s38"}
+{"__version": 220, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "gU2Q8lZV9GKEOKF0dLrBHiFOX7E1obA7bRkQKmkLY923lQarnBNiO8Gi/EsSCh/D", "games.py": "I+cktT3rD/gXlFYHmQpT8GHBfqR8VIjI4c6NHM68rn9gJJL/xu9AsOSLZys71s38"}


### PR DESCRIPTION
The previous worker code posted the PGN to the server in an encoded and
 zlib-compressed format. This required the server to decompress and decode
 the data before serving the PGN as text, resulting in significant CPU
 and network overhead. Furthermore, a bulk download of all PGNs from a run
 necessitated additional CPU overhead for compression.

The updated worker code posts a zip file containing the PGN text
 to the server, leading to more efficient handling on the server side:
- for single PGN downloads, the server simply serves
 the zipped PGN retrieved from MongoDB
- for bulk PGN downloads, the server writes a zip file in store mode
 containing all the zipped PGNs retrieved from MongoDB

@peregrineshahin wrote the bulk download code in https://github.com/official-stockfish/fishtest/pull/1804

closes https://github.com/official-stockfish/fishtest/issues/1801