### PR TITLE
Implement efficient PGN upload and bulk download - gzip and tar

### DIFF
--- a/server/fishtest/__init__.py
+++ b/server/fishtest/__init__.py
@@ -116,7 +116,7 @@ def main(global_config, **settings):
     config.add_route("api_get_task", "/api/get_task/{id}/{task_id}")
     config.add_route("api_upload_pgn", "/api/upload_pgn")
     config.add_route("api_download_pgn", "/api/pgn/{id}")
-    config.add_route("api_download_pgn_100", "/api/pgn_100/{skip}")
+    config.add_route("api_download_run_pgns", "/api/run_pgns/{id}")
     config.add_route("api_download_nn", "/api/nn/{id}")
     config.add_route("api_get_elo", "/api/get_elo/{id}")
     config.add_route("api_actions", "/api/actions")

--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -27,7 +27,7 @@ db directly. However this information may be slightly outdated, depending
 on how frequently the main instance flushes its run cache.
 """
 
-WORKER_VERSION = 220
+WORKER_VERSION = 221
 
 
 def validate_request(request):

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -1,7 +1,8 @@
 import base64
+import gzip
+import io
 import sys
 import unittest
-import zlib
 from datetime import datetime, timezone
 
 from fishtest.api import WORKER_VERSION, ApiView
@@ -375,22 +376,28 @@ class TestApi(unittest.TestCase):
 
     def test_upload_pgn(self):
         run_id = new_run(self, add_tasks=1)
+        task_id = 0
         pgn_text = "1. e4 e5 2. d4 d5"
-        request = self.correct_password_request(
-            {
-                "run_id": run_id,
-                "task_id": 0,
-                "pgn": base64.b64encode(
-                    zlib.compress(pgn_text.encode("utf-8"))
-                ).decode(),
-            }
-        )
+        with io.BytesIO() as gz_buffer:
+            with gzip.GzipFile(
+                filename=f"{run_id}-{task_id}.pgn.gz", mode="wb", fileobj=gz_buffer
+            ) as gz:
+                gz.write(pgn_text.encode())
+            request = self.correct_password_request(
+                {
+                    "run_id": run_id,
+                    "task_id": task_id,
+                    "pgn": base64.b64encode(gz_buffer.getvalue()).decode(),
+                }
+            )
         response = ApiView(request).upload_pgn()
         response.pop("duration", None)
         self.assertTrue(response == {})
 
-        pgn_filename_prefix = "{}-{}".format(run_id, 0)
-        pgn = self.rundb.get_pgn(pgn_filename_prefix)
+        pgn_filename_prefix = "{}-{}".format(run_id, task_id)
+        zip_pgn = self.rundb.get_pgn(pgn_filename_prefix)
+        with gzip.GzipFile(fileobj=io.BytesIO(zip_pgn), mode="rb") as gz:
+            pgn = gz.read().decode()
         self.assertEqual(pgn, pgn_text)
         self.rundb.pgndb.delete_one({"run_id": pgn_filename_prefix})
 

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 220, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "zMpxJoKT+iIxoYN7YYRqWanhc+R+/pN+y7bZL2zySO9EOIePf7LDQLbQbX2DpD7l", "games.py": "I+cktT3rD/gXlFYHmQpT8GHBfqR8VIjI4c6NHM68rn9gJJL/xu9AsOSLZys71s38"}
+{"__version": 220, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "z2DhnrMHUSnFzl1SgS+ixrD4qYRzTNM99Y/K91qNDkq1PfaVmyfNxBO2APp91cVI", "games.py": "I+cktT3rD/gXlFYHmQpT8GHBfqR8VIjI4c6NHM68rn9gJJL/xu9AsOSLZys71s38"}

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 220, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "z2DhnrMHUSnFzl1SgS+ixrD4qYRzTNM99Y/K91qNDkq1PfaVmyfNxBO2APp91cVI", "games.py": "I+cktT3rD/gXlFYHmQpT8GHBfqR8VIjI4c6NHM68rn9gJJL/xu9AsOSLZys71s38"}
+{"__version": 221, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "6LoP8vE7iFc/DFRdkMZ66FwBHtjKNt4MRaiBs7XpLRyrkWxfZNEMwcfyZxvs/XKJ", "games.py": "I+cktT3rD/gXlFYHmQpT8GHBfqR8VIjI4c6NHM68rn9gJJL/xu9AsOSLZys71s38"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -55,7 +55,7 @@ from updater import update
 # Several packages are called "expression".
 # So we make sure to use the locally installed one.
 
-WORKER_VERSION = 220
+WORKER_VERSION = 221
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0


### PR DESCRIPTION
The previous worker code posted the PGN to the server in a zlib-compressed format. This required the server to decompress the data before serving the PGN as text, resulting in significant CPU and network overhead. Furthermore, a bulk download of all PGNs from a run necessitated additional CPU overhead for compression.

The updated worker code posts a gzip file containing the PGN text to the server, leading to more efficient handling on the server side:
- for single PGN downloads, the server simply serves the gzipped PGN retrieved from MongoDB. All modern browsers decompress the gzip file client side, so the user will get the pgn as text file. nginx can be configured to decompress on the fly the gzip content for a client that is not declaring his compression capability.
- for bulk PGN downloads, the server writes a tar file containing all the gzipped PGNs retrieved from MongoDB ``` wget https://test.stockfishchess.org/api/run_pgns/<run_id>.pgns.tar ```
- gzip module uses zlib, no change for the compression ratio.

@peregrineshahin wrote the bulk download code
in https://github.com/official-stockfish/fishtest/pull/1804

Retire "pgn_100" api.

closes https://github.com/official-stockfish/fishtest/issues/1801