### PR TITLE
Switch to strict parsing of worker api's.

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -69,7 +69,7 @@ def validate_request(request):
             "pentanomial": [int, int, int, int, int],
         },
     }
-    return validate(schema, request, "request")
+    return validate(schema, request, "request", strict=True)
 
 
 # Avoids exposing sensitive data about the workers to the client and skips some heavy data.


### PR DESCRIPTION
Currently workers can add arbitrary fields to the api payloads, some of which may find their way into the db. This PR makes this impossible.

Note: strict parsing is possible thanks to the fix of a validation bug in #1811.