### PR TITLE
New default book for tests

### DIFF
--- a/server/fishtest/templates/tests_run.mak
+++ b/server/fishtest/templates/tests_run.mak
@@ -4,8 +4,8 @@
   from fishtest.util import format_bounds
   elo_model = "normalized"
   fb = lambda e0, e1: format_bounds(elo_model, e0, e1)
-  test_book = "UHO_4060_v3.epd"
-  pt_book = test_book
+  test_book = "UHO_Lichess_4852_v1.epd"
+  pt_book = "UHO_4060_v3.epd"
 %>
 <%
   base_branch = args.get('base_tag', 'master')


### PR DESCRIPTION
A new book with better properties for testing as described in

https://github.com/official-stockfish/books/commit/426eca422c202ef381a1380ada1873a7f185c4b9

favorable draw rate of about 50%
https://tests.stockfishchess.org/tests/view/6533f394de6d262d08d3a55e

Similar to our current book (which is in fact pretty good) in Elo detection: https://tests.stockfishchess.org/tests/view/6534127dde6d262d08d3a76a https://tests.stockfishchess.org/tests/view/65341296de6d262d08d3a76f

This should (if done correctly) no affect the book for progression testing, this we can leave at the old version, to ensure continuity.