### PR TITLE
Small cleanups in the run db.

### DIFF
--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -1280,7 +1280,6 @@ def tests_live_elo(request):
     run = request.rundb.get_run(request.matchdict["id"])
     if run is None:
         raise exception_response(404)
-    request.rundb.get_results(run)
     return {"run": run, "page_title": get_page_title(run)}
 
 
@@ -1289,7 +1288,6 @@ def tests_stats(request):
     run = request.rundb.get_run(request.matchdict["id"])
     if run is None:
         raise exception_response(404)
-    request.rundb.get_results(run)
     return {"run": run, "page_title": get_page_title(run)}
 
 
@@ -1330,7 +1328,7 @@ def tests_view(request):
         follow = 1
     else:
         follow = 0
-    results = request.rundb.get_results(run)
+    results = run["results"]
     run["results_info"] = format_results(results, run)
     run_args = [("id", str(run["_id"]), "")]
     if run.get("rescheduled_from"):

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -198,7 +198,6 @@ class TestApi(unittest.TestCase):
     def test_update_task(self):
         run_id = new_run(self, add_tasks=1)
         run = self.rundb.get_run(run_id)
-        self.assertFalse(run["results_stale"])
 
         # Request fails if username/password is invalid
         with self.assertRaises(HTTPUnauthorized):
@@ -223,7 +222,6 @@ class TestApi(unittest.TestCase):
         )
         response = ApiView(cleanup(request)).update_task()
         self.assertTrue(response["task_alive"])
-        self.assertFalse(self.rundb.get_run(run_id)["results_stale"])
 
         # Task is still active
         cs = self.chunk_size
@@ -238,7 +236,6 @@ class TestApi(unittest.TestCase):
         }
         response = ApiView(cleanup(request)).update_task()
         self.assertTrue(response["task_alive"])
-        self.assertFalse(self.rundb.get_run(run_id)["results_stale"])
 
         # Task is still active. Odd update.
         request.json_body["stats"] = {
@@ -309,7 +306,6 @@ class TestApi(unittest.TestCase):
             "pentanomial": [0, 0, 0, 0, task_num_games // 2],
         }
         response = ApiView(cleanup(request)).update_task()
-        self.assertFalse(self.rundb.get_run(run_id)["results_stale"])
         self.assertFalse(response["task_alive"])
         run = self.rundb.get_run(run_id)
         task = run["tasks"][0]
@@ -613,7 +609,6 @@ class TestRunFinished(unittest.TestCase):
         # The run should be marked as finished after the last task completes
         run = self.rundb.get_run(run_id)
         self.assertTrue(run["finished"])
-        self.assertFalse(run["results_stale"])
         self.assertTrue(all([not t["active"] for t in run["tasks"]]))
         self.assertTrue("Total: {}".format(num_games) in run["results_info"]["info"][1])
 


### PR DESCRIPTION
- Remove the field `"results_stale"` since now the results are updated incrementally. So they should never be stale.

- Retire `get_results()` and replace it by `compute_results()` which has no side effects (`get_results()` was terrible from this point of view). `compute_results()` is called in two places: 
   - in `purge_run()` 
   - after a run is finished to verify the incrementally updated results.
- Set the `"workers"` and `"cores"` fields equal to zero when the run is finished.