### PR TITLE
After introduction of a itp correction based on number of running tests we have the odd situation that running more then 6 tests leads to a smaller total itp (and so total cores). Here the formula is changed that the total itp for more than 6 running tests is fixed to the same value as if tunning 6 tests.

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -671,7 +671,11 @@ class RunDb:
                 itp *= bonus
 
         # Malus for too many active runs
-        itp *= 36.0 / (36.0 + count * count)
+        if count > 6:
+            # total itp for all user tests is the same as for 6 running tests
+            itp *= 3.0 / count
+        else:
+            itp *= 36.0 / (36.0 + count * count)
 
         run["args"]["itp"] = itp
 


### PR DESCRIPTION
…ts we have the odd situation that running more then 6 tests leads to a smaller total itp (and so total cores). Here the formula is changed that the total itp for more than 6 running tests is fixed to the same value as if tunning 6 tests.