### PR TITLE
Silence unit tests by setting sys.stdout to None during tests

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -45,7 +45,7 @@ jobs:
         id: isort
         continue-on-error: true
         run: |
-          pipx run isort --check --profile black --skip worker/packages .
+          pipx run isort --check --profile black --df --skip worker/packages .
 
       - name: Run prettier
         id: prettier

--- a/server/fishtest/userdb.py
+++ b/server/fishtest/userdb.py
@@ -52,10 +52,10 @@ class UserDb:
     def authenticate(self, username, password):
         user = self.find(username)
         if not user or user["password"] != password:
-            sys.stderr.write("Invalid login: '{}' '{}'\n".format(username, password))
+            print("Invalid login: '{}' '{}'\n".format(username, password), flush=True)
             return {"error": "Invalid password for user: {}".format(username)}
         if "blocked" in user and user["blocked"]:
-            sys.stderr.write("Blocked login: '{}' '{}'\n".format(username, password))
+            print("Blocked login: '{}' '{}'\n".format(username, password), flush=True)
             return {"error": "Account blocked for user: {}".format(username)}
 
         return {"username": username, "authenticated": True}

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -421,7 +421,7 @@ def post_in_fishcooking_results(run):
         s.sendmail(msg["From"], [msg["To"]], msg.as_string())
         s.quit()
     except ConnectionRefusedError:
-        print("Unable to post results to fishcooking forum")
+        print("Unable to post results to fishcooking forum", flush=True)
 
 
 def diff_date(date):

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -3,6 +3,7 @@ import copy
 import gzip
 import io
 import sys
+import time
 import unittest
 from datetime import datetime, timezone
 
@@ -70,6 +71,8 @@ def stop_all_runs(self):
 class TestApi(unittest.TestCase):
     @classmethod
     def setUpClass(self):
+        self.stdout = sys.stdout
+        sys.stdout = None
         self.chunk_size = 200
         self.rundb = get_rundb()
         # Set up an API user (a worker)
@@ -122,6 +125,7 @@ class TestApi(unittest.TestCase):
         self.rundb.userdb.user_cache.delete_many({"username": self.username})
         self.rundb.stop()
         self.rundb.runs.drop()
+        sys.stdout = self.stdout
 
     def build_json_request(self, json_body):
         return DummyRequest(
@@ -453,6 +457,8 @@ class TestApi(unittest.TestCase):
 class TestRunFinished(unittest.TestCase):
     @classmethod
     def setUpClass(self):
+        self.stdout = sys.stdout
+        sys.stdout = None
         self.chunk_size = 200
         self.rundb = get_rundb()
         # Set up an API user (a worker)
@@ -504,6 +510,7 @@ class TestRunFinished(unittest.TestCase):
         self.rundb.userdb.user_cache.delete_many({"username": self.username})
         self.rundb.stop()
         self.rundb.runs.drop()
+        sys.stdout = self.stdout
 
     def build_json_request(self, json_body):
         return DummyRequest(

--- a/server/tests/test_users.py
+++ b/server/tests/test_users.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 from datetime import datetime, timezone
 
@@ -8,6 +9,8 @@ from pyramid import testing
 
 class Create10UsersTest(unittest.TestCase):
     def setUp(self):
+        self.stdout = sys.stdout
+        sys.stdout = None
         self.rundb = util.get_rundb()
         self.config = testing.setUp()
         self.config.add_route("login", "/login")
@@ -17,6 +20,7 @@ class Create10UsersTest(unittest.TestCase):
         self.rundb.userdb.users.delete_many({"username": "JoeUser"})
         self.rundb.userdb.user_cache.delete_many({"username": "JoeUser"})
         self.rundb.stop()
+        sys.stdout = self.stdout
         testing.tearDown()
 
     def test_create_user(self):
@@ -37,6 +41,8 @@ class Create10UsersTest(unittest.TestCase):
 
 class Create50LoginTest(unittest.TestCase):
     def setUp(self):
+        self.stdout = sys.stdout
+        sys.stdout = None
         self.rundb = util.get_rundb()
         self.rundb.userdb.create_user("JoeUser", "secret", "email@email.email")
         self.config = testing.setUp()
@@ -46,6 +52,7 @@ class Create50LoginTest(unittest.TestCase):
         self.rundb.userdb.users.delete_many({"username": "JoeUser"})
         self.rundb.userdb.user_cache.delete_many({"username": "JoeUser"})
         self.rundb.stop()
+        sys.stdout = self.stdout
         testing.tearDown()
 
     def test_login(self):


### PR DESCRIPTION
We also deleted a few print statement that were obviously leftover debug prints.

We changed two messages in userdb.py from stderr to stdout.

This is an improved version of #1845 
```
$ ~/fishtest/server/tests$ python -m unittest -v
test_beat (test_api.TestApi) ... ok
test_failed_task (test_api.TestApi) ... ok
test_get_active_runs (test_api.TestApi) ... ok
test_get_elo (test_api.TestApi) ... ok
test_get_run (test_api.TestApi) ... ok
test_request_spsa (test_api.TestApi) ... ok
test_request_task (test_api.TestApi) ... ok
test_request_version (test_api.TestApi) ... ok
test_stop_run (test_api.TestApi) ... ok
test_update_task (test_api.TestApi) ... ok
test_upload_pgn (test_api.TestApi) ... ok
test_auto_purge_runs (test_api.TestRunFinished) ... ok
test_duplicate_workers (test_api.TestRunFinished) ... ok
test_10_get_bench (test_run.CreateRunTest) ... ok
test_10_create_run (test_rundb.CreateRunDBTest) ... ok
test_20_update_task (test_rundb.CreateRunDBTest) ... ok
test_30_finish (test_rundb.CreateRunDBTest) ... ok
test_90_delete_runs (test_rundb.CreateRunDBTest) ... ok
test_create_user (test_users.Create10UsersTest) ... ok
test_login (test_users.Create50LoginTest) ... ok
test_keys (test_validate.TestValidation) ... ok
test_missing_keys (test_validate.TestValidation) ... ok
test_strict (test_validate.TestValidation) ... ok
test_union (test_validate.TestValidation) ... ok
test_validate (test_validate.TestValidation) ... ok

----------------------------------------------------------------------
Ran 25 tests in 9.287s

OK
```