### PR TITLE
convert FENs in .epd to EPDs with move counters

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -27,7 +27,7 @@ db directly. However this information may be slightly outdated, depending
 on how frequently the main instance flushes its run cache.
 """
 
-WORKER_VERSION = 222
+WORKER_VERSION = 223
 
 
 def validate_request(request):

--- a/worker/games.py
+++ b/worker/games.py
@@ -457,6 +457,24 @@ def unzip(blob, save_dir):
     return file_list
 
 
+def convert_book_move_counters(book_file):
+    # converts files with complete FENs, leaving others (incl. converted ones) unchanged
+    epds = []
+    with open(book_file, "r") as file:
+        for fen in file:
+            fields = fen.split()
+            if len(fields) == 6:
+                fields[4] = f"hmvc {fields[4]};"
+                fields[5] = f"fmvn {fields[5]};"
+                epds.append(" ".join(fields))
+            else:
+                return
+
+    with open(book_file, "w") as file:
+        for epd in epds:
+            file.write(epd + "\n")
+
+
 def clang_props():
     """Parse the output of clang++ -E - -march=native -### and extract the available clang properties"""
     with subprocess.Popen(
@@ -1287,6 +1305,11 @@ def run_games(worker_info, password, remote, run, task_id, pgn_file, clear_binar
         zipball = book + ".zip"
         blob = download_from_github(zipball)
         unzip(blob, testing_dir)
+
+    # convert .epd containing FENs into .epd containing EPDs with move counters
+    # only needed as long as cutechess-cli is the game manager
+    if book.endswith(".epd"):
+        convert_book_move_counters(testing_dir / book)
 
     # Clean up the old networks (keeping the num_bkps most recent)
     num_bkps = 10

--- a/worker/games.py
+++ b/worker/games.py
@@ -463,7 +463,7 @@ def convert_book_move_counters(book_file):
     with open(book_file, "r") as file:
         for fen in file:
             fields = fen.split()
-            if len(fields) == 6:
+            if len(fields) == 6 and fields[4].isdigit() and fields[5].isdigit():
                 fields[4] = f"hmvc {fields[4]};"
                 fields[5] = f"fmvn {fields[5]};"
                 epds.append(" ".join(fields))

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 223, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "tWGFtSueD2bUphYamJq+5AR+fB6fQTKU+e8JoNKBp3ebj5JyP6Y/nA7e28S/kuVZ", "games.py": "WQklR1GIvAJDJ+UFZB7wGdMvwzShZyTqh74rwabvjHkFxpN/tWPDWKJz0bOAOdbL"}
+{"__version": 223, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "tWGFtSueD2bUphYamJq+5AR+fB6fQTKU+e8JoNKBp3ebj5JyP6Y/nA7e28S/kuVZ", "games.py": "k0HHaT2Jw/RVoWgZOkywOZX2dgWKqznXKFKBpFTQkp9apmlYK3ecX9ilpoUvW9ei"}

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 222, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "9RVstpWvQ/yVTHckLMbwE0+bat+pBj0IKxTdDjhwsN6/EElf9+FARDLRCFLrVg5v", "games.py": "I+cktT3rD/gXlFYHmQpT8GHBfqR8VIjI4c6NHM68rn9gJJL/xu9AsOSLZys71s38"}
+{"__version": 223, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "tWGFtSueD2bUphYamJq+5AR+fB6fQTKU+e8JoNKBp3ebj5JyP6Y/nA7e28S/kuVZ", "games.py": "WQklR1GIvAJDJ+UFZB7wGdMvwzShZyTqh74rwabvjHkFxpN/tWPDWKJz0bOAOdbL"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -55,7 +55,7 @@ from updater import update
 # Several packages are called "expression".
 # So we make sure to use the locally installed one.
 
-WORKER_VERSION = 222
+WORKER_VERSION = 223
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0


### PR DESCRIPTION
This PR changes downloaded (and existing) `.epd` books in the testing directory: if all lines contain full FENs (with 6 fields, including both move counters), then these are converted into the corresponding EPDs.  `cutechess-cli` only supports the latter as input from `.epd` files, and hence replaces all existing move counters with `0 1`.

With the change the playing stockfish versions will have access to the correct move number, and so even with future changes to the WDL model (where the normalization constant may become ply dependent) the correct evaluations will be displayed.

Note that this PR implements option (3) as discussed with @vondele on [discord](https://discord.com/channels/435943710472011776/1032922913499783169/1170759469903401091)

Update: [Link](https://discord.com/channels/435943710472011776/900771437177094156/1171195594765774899) to discord discussion of this PR.