### PR TITLE
Adjusting the score threshold for draws

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,6 +10,7 @@ David (dav1312)
 David Zar
 dubslow
 Fabian Fichter (ianfab)
+Fauzi Akram (fauzi2)
 Fanael Linithien (Fanael)
 FieryDragonLord
 Giacomo Lorenzetti (G-Lorenz)

--- a/worker/games.py
+++ b/worker/games.py
@@ -1444,7 +1444,7 @@ def run_games(worker_info, password, remote, run, task_id, pgn_file, clear_binar
                     "-draw",
                     "movenumber=34",
                     "movecount=8",
-                    "score=20",
+                    "score=16",
                 ]
                 if run["args"].get("adjudication", True)
                 else []


### PR DESCRIPTION
I suggest adjusting the score threshold for draws from 20 to 16. Here are the reasons for this proposed change:

Reducing Premature Draws: The current threshold of 20 may result in premature draws, especially in complex positions where small imbalances can still lead to decisive outcomes. Increasing the threshold to 16 would allow the game to develop further before considering it a draw.

Encouraging Dynamic Play: A higher threshold promotes more dynamic play, as sides would have to demonstrate a more significant advantage to secure a draw.

Alignment with Modern SF Assessments: SF evaluation has evolved, and now considers scores above 16 as an advantage.