### PR TITLE
Tighten up the schema in api.py.

### DIFF
--- a/server/tests/test_rundb.py
+++ b/server/tests/test_rundb.py
@@ -36,7 +36,7 @@ class CreateRunDBTest(unittest.TestCase):
                 3,
                 0,
             ],
-            "unique_key": "unique key",
+            "unique_key": "amaya-5a28-4b7d-b27b-d78d97ecf11a",
             "near_github_api_limit": False,
             "modified": True,
             "ARCH": "?",


### PR DESCRIPTION
The api's in api.py are a direct connection between the workers and the db. So it makes sense to be very strict in what we accept.

Note: a serious bug was discovered in the handling of optional keys in vtjson. So vtjson should be upgraded to the latest version. Since upgrading is necessary anyway, this PR depends on a previously internal feature of vtjson, namely the possibility to pre-compile a schema.

Validating an update_task api call for an SPRT run takes 0.026ms on an AWS entry level t2.micro using Python 3.11 (without pre-compiling it takes 0.068ms).