### PR TITLE
Shut down the worker quickly after receiving SIGINT during make.

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -699,11 +699,21 @@ def setup_engine(
             cmd,
             shell=True,
             env=env,
+            stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             universal_newlines=True,
             bufsize=1,
             close_fds=not IS_WINDOWS,
         ) as p:
+            try:
+                for out in p.stdout:
+                    print(out.strip())
+            except Exception as e:
+                p.send_signal(signal.SIGINT)
+                raise FatalException(
+                    f"Executing {cmd} raised Exception: {e.__class__.__name__}: {str(e)}",
+                    e=e,
+                )
             errors = p.stderr.readlines()
         if p.returncode:
             raise WorkerException("Executing {} failed. Error: {}".format(cmd, errors))

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 224, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "QggkAE0oS9YfF29AZS+CoHuv5Fm0iGrHsEcS8qw6+GMrbrFfQywKIvAZXCWKSX6U", "games.py": "m8sYwhGaxwIMl2ShvZd802KMKu+0qqpKCQmXkDHazzvkE59Y9Un1uhhGUHNnWN1u"}
+{"__version": 224, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "QggkAE0oS9YfF29AZS+CoHuv5Fm0iGrHsEcS8qw6+GMrbrFfQywKIvAZXCWKSX6U", "games.py": "3J10RceI0vVIS1/KmGj+Rvb94sS4x8P+96JxsQM0UPMNpqZkWlqQi4SGGvfdWC8B"}


### PR DESCRIPTION
To test this PR (on Linux, see below) one may run the worker in one terminal and during compiling send a `SIGINT` or `SIGTERM` to the python process from another terminal (e.g. via `kill <PID-python>`).  A worker running `master` will only stop when the `make` command finishes. If the worker runs this PR then it will stop immediately and clean up. 

I assume this PR will be useful if the worker is started via a service manager like `systemd` which typically stops a service by sending a `SIGTERM` to the main process. I have not tested this however.

This PR currently has no effect on `Windows` as the mechanism for terminating processes is different. Probably there is also no need for this PR on that OS. 
