### PR TITLE
Shut down the worker quickly after receiving SIGINT.

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -437,12 +437,14 @@ def download_from_github(
 ):
     try:
         blob = download_from_github_raw(item, owner=owner, repo=repo, branch=branch)
-    except:
-        print("Downloading {} failed. Trying the GitHub api.".format(item))
+    except FatalException as e:
+        raise (e)
+    except Exception as e:
+        print(f"Downloading {item} failed: {str(e)}. Trying the GitHub api.")
         try:
             blob = download_from_github_api(item, owner=owner, repo=repo, branch=branch)
-        except:
-            raise WorkerException("Unable to download {}".format(item))
+        except Exception as e:
+            raise WorkerException(f"Unable to download {item}", e=e)
     return blob
 
 

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 224, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "QggkAE0oS9YfF29AZS+CoHuv5Fm0iGrHsEcS8qw6+GMrbrFfQywKIvAZXCWKSX6U", "games.py": "m8sYwhGaxwIMl2ShvZd802KMKu+0qqpKCQmXkDHazzvkE59Y9Un1uhhGUHNnWN1u"}
+{"__version": 224, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "sFuenPMaOH0KAKiXyl0hB8m+MAUv63gn6tYmoZVPLhetFQgEcjDXnGnCBwqKaazx", "games.py": "u54LJfauLaYdOBDCXzsnIM/O8sA4jYRs0eU4xwuM5wFdSnstj6Vtk+Od6sEoFp/z"}

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 224, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "sFuenPMaOH0KAKiXyl0hB8m+MAUv63gn6tYmoZVPLhetFQgEcjDXnGnCBwqKaazx", "games.py": "u54LJfauLaYdOBDCXzsnIM/O8sA4jYRs0eU4xwuM5wFdSnstj6Vtk+Od6sEoFp/z"}
+{"__version": 224, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "+X0k5F8M5Q1TRoJ3Puq2gFbQnTvybdQ7wfNoGNB6Gvb+0huwwsfScUOkpxBW1mgX", "games.py": "u54LJfauLaYdOBDCXzsnIM/O8sA4jYRs0eU4xwuM5wFdSnstj6Vtk+Od6sEoFp/z"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -1506,12 +1506,12 @@ def worker():
         # Try to make sure the worker has its own process group so that we can easily kill
         # all subprocesses.
 
-        print(f"Before: PID={os.getpid()} PGID={os.getpgid(0)}")
+        print(f"Before: PID={os.getpid()} PPID={os.getppid()} PGID={os.getpgid(0)}")
         
         pid = os.getpid()
         try:
             os.setpgid(0, pid)
-            print(f"After: PID={os.getpid()} PGID={os.getpgid(0)}")
+            print(f"After: PID={os.getpid()} PPID={os.getppid()} PGID={os.getpgid(0)}")
         except Exception as e:
             print(
                 "Unable to move the worker to its own group:",

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -1502,13 +1502,16 @@ def worker():
 
     print(LOGO)
 
-    if not IS_WINDOWS and not sys.stdout.isatty():
+    if not IS_WINDOWS:
         # Try to make sure the worker has its own process group so that we can easily kill
         # all subprocesses.
-        # We assume that if it is started in a shell then it is already in its own group.
+
+        print(f"Before: PID={os.getpid()} PGID={os.getpgid(0)}")
+        
         pid = os.getpid()
         try:
             os.setpgid(0, pid)
+            print(f"After: PID={os.getpid()} PGID={os.getpgid(0)}")
         except Exception as e:
             print(
                 "Unable to move the worker to its own group:",


### PR DESCRIPTION
To test this PR (on Linux, see below) one may run the worker in one terminal and during compiling send a SIGINT or SIGTERM to the python process from another terminal (e.g. via kill <PID-python>). A worker running master will only stop when the make command finishes. If the worker runs this PR then it will stop immediately and clean up.

I assume this PR will be useful if the worker is started via a service manager like systemd which typically stops a service by sending a SIGTERM to the main process. I have not tested this however.

This PR currently has no effect on Windows as the mechanism for terminating processes is different. Probably there is also no need for this PR on that OS.