### PR TITLE
Shut down the worker quickly after receiving SIGINT.

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -28,7 +28,7 @@ db directly. However this information may be slightly outdated, depending
 on how frequently the main instance flushes its run cache.
 """
 
-WORKER_VERSION = 224
+WORKER_VERSION = 225
 
 """
 begin api_schema

--- a/worker/games.py
+++ b/worker/games.py
@@ -703,6 +703,7 @@ def setup_engine(
             cmd,
             shell=True,
             env=env,
+            start_new_session=False if IS_WINDOWS else True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             universal_newlines=True,
@@ -714,7 +715,7 @@ def setup_engine(
                     print(out.strip())
             except Exception as e:
                 if not IS_WINDOWS:
-                    p.send_signal(signal.SIGINT)
+                    os.killpg(p.pid, signal.SIGINT)
                 raise WorkerException(
                     f"Executing {cmd} raised Exception: {e.__class__.__name__}: {str(e)}",
                     e=e,

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 224, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "QggkAE0oS9YfF29AZS+CoHuv5Fm0iGrHsEcS8qw6+GMrbrFfQywKIvAZXCWKSX6U", "games.py": "bjiztHma22FxtqmAFeSShhOXo8qGeKgAIuao9dp63+ypHVrvsVBGNsckAWS0Glde"}
+{"__version": 224, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "QggkAE0oS9YfF29AZS+CoHuv5Fm0iGrHsEcS8qw6+GMrbrFfQywKIvAZXCWKSX6U", "games.py": "7szyHwmVhZxkiiEjEOXjCrYnys7P5aAUBef5HFa2yh8FSBXggHGKAS2G0+Qq8KsP"}

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 224, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "QggkAE0oS9YfF29AZS+CoHuv5Fm0iGrHsEcS8qw6+GMrbrFfQywKIvAZXCWKSX6U", "games.py": "m8sYwhGaxwIMl2ShvZd802KMKu+0qqpKCQmXkDHazzvkE59Y9Un1uhhGUHNnWN1u"}
+{"__version": 224, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "QggkAE0oS9YfF29AZS+CoHuv5Fm0iGrHsEcS8qw6+GMrbrFfQywKIvAZXCWKSX6U", "games.py": "bjiztHma22FxtqmAFeSShhOXo8qGeKgAIuao9dp63+ypHVrvsVBGNsckAWS0Glde"}

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 224, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "QggkAE0oS9YfF29AZS+CoHuv5Fm0iGrHsEcS8qw6+GMrbrFfQywKIvAZXCWKSX6U", "games.py": "7szyHwmVhZxkiiEjEOXjCrYnys7P5aAUBef5HFa2yh8FSBXggHGKAS2G0+Qq8KsP"}
+{"__version": 225, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "Hyq1aYXjX1uofUnSW9EGBXTQN0Jfjz7+LExmFxe6qLQEX1w8vxFQOpWTrRV4YZZz", "games.py": "7szyHwmVhZxkiiEjEOXjCrYnys7P5aAUBef5HFa2yh8FSBXggHGKAS2G0+Qq8KsP"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -55,7 +55,7 @@ from updater import update
 # Several packages are called "expression".
 # So we make sure to use the locally installed one.
 
-WORKER_VERSION = 224
+WORKER_VERSION = 225
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0


### PR DESCRIPTION
To test this PR (on Linux, see below) one may run the worker in one terminal and during compiling send a SIGINT or SIGTERM to the python process from another terminal (e.g. via kill <PID-python>). A worker running master will only stop when the make command finishes. If the worker runs this PR then it will stop immediately and clean up.

This PR currently has no effect on Windows as the mechanism for terminating processes is different. Probably there is also no need for this PR on that OS.

This PR is less general than #1864 but also much more trivial.