### PR TITLE
Convenient link to blocked workers

### DIFF
--- a/server/fishtest/templates/tasks.mak
+++ b/server/fishtest/templates/tasks.mak
@@ -30,7 +30,7 @@
       <td>
     % endif
     % if approver and task['worker_info']['username'] != "Unknown_worker":
-      <a href="/user/${task['worker_info']['username']}">
+      <a href="/workers/${worker_name(task['worker_info'], short=True)}">
         ${worker_name(task['worker_info'])}
       </a>
     % elif 'worker_info' in task:


### PR DESCRIPTION
Currently, there is no convenient way to get to the particular worker page to block/unblock after misbehaving workers are spotted in test_view Tasks. You would need to write the URL manually or search for that worker on the home page.

Make the approver-only anchor redirect to the worker management rather than the user page as the user page is irrelevant after we can block only the worker.