### PR TITLE
Improve bench regex pattern

### DIFF
--- a/server/tests/test_run.py
+++ b/server/tests/test_run.py
@@ -10,7 +10,9 @@ class CreateRunTest(unittest.TestCase):
             "https://api.github.com/repos/official-stockfish/Stockfish/commits"
         )
         self.assertTrue(
-            re.match("[0-9]{7}|None", str(get_master_info(master_commits_url)["bench"]))
+            re.match(
+                r"[1-9]\d{5,7}|None", str(get_master_info(master_commits_url)["bench"])
+            )
         )
 
 


### PR DESCRIPTION
Updated the bench regex pattern to match the correct format of the bench number.
Thanks to @Disservin for reporting the bug.