### PR TITLE
Generalize the EvalFile net option detection

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -28,7 +28,7 @@ db directly. However this information may be slightly outdated, depending
 on how frequently the main instance flushes its run cache.
 """
 
-WORKER_VERSION = 226
+WORKER_VERSION = 227
 
 """
 begin api_schema

--- a/worker/games.py
+++ b/worker/games.py
@@ -231,8 +231,9 @@ def github_api(repo):
     return repo.replace("https://github.com", "https://api.github.com/repos")
 
 
-def required_net(engine):
-    net = None
+def required_nets(engine):
+    nets = {}
+    pattern = re.compile(r"(EvalFile\w*)\s+.*\s+(nn-[a-f0-9]{12}.nnue)")
     print("Obtaining EvalFile of {} ...".format(os.path.basename(engine)))
     try:
         with subprocess.Popen(
@@ -243,10 +244,10 @@ def required_net(engine):
             close_fds=not IS_WINDOWS,
         ) as p:
             for line in iter(p.stdout.readline, ""):
-                if "EvalFile" in line:
-                    m = re.search("nn-[a-f0-9]{12}.nnue", line)
-                    if m:
-                        net = m.group(0)
+                match = pattern.search(line)
+                if match:
+                    nets[match.group(1)] = match.group(2)
+
     except (OSError, subprocess.SubprocessError) as e:
         raise WorkerException(
             "Unable to obtain name for required net. Error: {}".format(str(e))
@@ -257,7 +258,7 @@ def required_net(engine):
             "UCI exited with non-zero code {}".format(format_return_code(p.returncode))
         )
 
-    return net
+    return nets
 
 
 def required_nets_from_source():
@@ -693,7 +694,13 @@ def setup_engine(
         # skip temporary the profiled build for apple silicon, see
         # https://stackoverflow.com/questions/71580631/how-can-i-get-code-coverage-with-clang-13-0-1-on-mac
         make_cmd = "build" if arch == "apple-silicon" else "profile-build"
-        cmd = f"make -j {concurrency} {make_cmd} ARCH={arch} COMP={comp}".split()
+        cmd = [
+            "make",
+            f"-j{concurrency}",
+            f"{make_cmd}",
+            f"ARCH={arch}",
+            f"COMP={comp}",
+        ]
 
         # append -DNNUE_EMBEDDING_OFF to existing CXXFLAGS environment variable, if any
         cxx = os.environ.get("CXXFLAGS", "") + " -DNNUE_EMBEDDING_OFF"
@@ -703,7 +710,6 @@ def setup_engine(
             cmd,
             env=env,
             start_new_session=False if IS_WINDOWS else True,
-            stdout=None,
             stderr=subprocess.PIPE,
             universal_newlines=True,
             bufsize=1,
@@ -721,16 +727,11 @@ def setup_engine(
         if p.returncode:
             raise WorkerException("Executing {} failed. Error: {}".format(cmd, errors))
 
-        # TODO: 'make strip' works fine with the new Makefile,
-        # 'try' should be safely dropped in the future
-        try:
-            subprocess.run(
-                ["make", "strip", f"COMP={comp}"],
-                stderr=subprocess.DEVNULL,
-                check=True,
-            )
-        except Exception as e:
-            print("Exception stripping binary:\n", e, sep="", file=sys.stderr)
+        subprocess.run(
+            ["make", "strip", f"COMP={comp}"],
+            stderr=subprocess.DEVNULL,
+            check=True,
+        )
 
         # We called setup_engine() because the engine was not cached.
         # Only another worker running in the same folder can have built the engine.
@@ -1340,17 +1341,14 @@ def run_games(worker_info, password, remote, run, task_id, pgn_file, clear_binar
                 file=sys.stderr,
             )
 
-    # Add EvalFile with full path to cutechess options, and download the networks if missimg.
-    net_base = required_net(base_engine)
-    if net_base:
-        base_options = base_options + ["option.EvalFile={}".format(net_base)]
-    net_new = required_net(new_engine)
-    if net_new:
-        new_options = new_options + ["option.EvalFile={}".format(net_new)]
+    # Add EvalFile* with full path to cutechess options, and download the networks if missing.
+    for option, net in required_nets(base_engine).items():
+        base_options.append("option.{}={}".format(option, net))
+        establish_validated_net(remote, testing_dir, net)
 
-    for net in (net_base, net_new):
-        if net:
-            establish_validated_net(remote, testing_dir, net)
+    for option, net in required_nets(new_engine).items():
+        new_options.append("option.{}={}".format(option, net))
+        establish_validated_net(remote, testing_dir, net)
 
     # PGN files output setup.
     pgn_name = "results-" + worker_info["unique_key"] + ".pgn"

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 226, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "AlzBfLw8QpQx5mQmOXedSHxcBG5v+Jw5pyW3gTeUsdDzi+23Jhf7T8gcIUGQFu0A", "games.py": "x0RFYFYsRObu/828o5qz0BBA9sAhiyiLSDJQvxFXpuqTEgZWZfN+jo5JFVUiemHX"}
+{"__version": 227, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "31vTijpebTtgec7U05c6RIcXrbfGN9XDnPOUxmKXjUz4FTNFEKS+PBz4tFWdkwEo", "games.py": "f1e0z+C2V35fIBN2Z9YVHeEfppzJLW11ABtNaXsbZhUrQlEKlNdRJDqJTzfBw/fq"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -55,7 +55,7 @@ from updater import update
 # Several packages are called "expression".
 # So we make sure to use the locally installed one.
 
-WORKER_VERSION = 226
+WORKER_VERSION = 227
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0


### PR DESCRIPTION
Stockfish will use more than one net with
https://github.com/official-stockfish/Stockfish/pull/4915

Get all the couples "option" and "net names" from the output of the
`stockfish uci` command.

Raise worker version to 227 (also server side)