### PR TITLE
Modifying the "Reduce ITP with number of active tests per user"

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,6 +11,7 @@ David Zar
 dubslow
 Fabian Fichter (ianfab)
 Fanael Linithien (Fanael)
+Fauzi Akram Dabat (Fauzi2)
 FieryDragonLord
 Gabe (MrBrain295)
 Giacomo Lorenzetti (G-Lorenz)

--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -865,7 +865,7 @@ class RunDb:
                 itp *= bonus
 
         # Malus for too many active runs
-        itp *= 36.0 / (36.0 + count * count)
+        itp *= 64.0 / (64.0 + count * count)
 
         run["args"]["itp"] = itp
 


### PR DESCRIPTION
Reasons for this change:

**Support for Active Developers:**

The current number of active developers is relatively low. Penalizing them with stringent bounds may discourage contributions. The proposed change ensures a more lenient approach, fostering a supportive environment for developers.

**Balancing Act:**

The adjustment strikes a balance between encouraging active testing and maintaining reasonable control over the number of tests. It provides a smoother reduction in itp as the number of active tests increases, offering a fair compromise.

**Community Feedback:**

I suggest seeking feedback from the fishtest community on this proposed change. Open discussions can provide valuable insights and help in refining the formula to better suit the collective needs of the community.