### PR TITLE
Introduce log_message action.

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -14,7 +14,7 @@ from pyramid.httpexceptions import (
 )
 from pyramid.response import Response
 from pyramid.view import exception_view_config, view_config, view_defaults
-from vtjson import _validate, compile, intersect, interval, lax, regex
+from vtjson import ValidationError, compile, intersect, interval, lax, regex, validate
 
 """
 Important note
@@ -109,7 +109,7 @@ end api_schema
 
 
 def validate_request(request):
-    return _validate(api_schema, request, "request")
+    validate(api_schema, request, "request")
 
 
 # Avoids exposing sensitive data about the workers to the client and skips some heavy data.
@@ -178,7 +178,10 @@ class ApiView(object):
 
         # Is the request syntactically correct?
         schema = lax({"password": str, "worker_info": {"username": str}})
-        self.handle_error(_validate(schema, self.request_body, "request"))
+        try:
+            validate(schema, self.request_body, "request")
+        except ValidationError as e:
+            self.handle_error(str(e))
 
         # is the supplied password correct?
         token = self.request.userdb.authenticate(
@@ -199,7 +202,10 @@ class ApiView(object):
         self.validate_username_password(api)
 
         # Is the request syntactically correct?
-        self.handle_error(validate_request(self.request_body))
+        try:
+            validate_request(self.request_body)
+        except ValidationError as e:
+            self.handle_error(str(e))
 
         # is a supplied run_id correct?
         if "run_id" in self.request_body:

--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -35,7 +35,7 @@ from fishtest.util import (
 )
 from fishtest.workerdb import WorkerDb
 from pymongo import DESCENDING, MongoClient
-from vtjson import _validate, ip_address, number, regex, union, url
+from vtjson import ValidationError, ip_address, number, regex, union, url, validate
 
 DEBUG = False
 
@@ -432,9 +432,10 @@ class RunDb:
         if rescheduled_from:
             new_run["rescheduled_from"] = rescheduled_from
 
-        valid = _validate(schema, new_run, "run")
-        if valid != "":
-            message = f"The new run object does not _validate: {valid}"
+        try:
+            validate(schema, new_run, "run")
+        except ValidationError as e:
+            message = f"The new run object does not validate: {str(e)}"
             print(message, flush=True)
             raise Exception(message)
 
@@ -1491,6 +1492,10 @@ After fixing the issues you can unblock the worker at
                 info = "Check_results: task {}/{} {} results mismatch: {}/{}".format(
                     run_id, task_id, s, old.get(s, -1), new.get(s, -1)
                 )
+                self.actiondb.log_message(
+                    username="fishtest.system",
+                    message=info,
+                )
                 print(info, flush=True)
 
         if (
@@ -1505,6 +1510,10 @@ After fixing the issues you can unblock the worker at
                 len(old.get("pentanomial", [])),
                 len(new.get("pentanomial", [])),
             )
+            self.actiondb.log_message(
+                username="fishtest.system",
+                message=info,
+            )
             print(info, flush=True)
         else:
             for i, (old_value, new_value) in enumerate(
@@ -1513,6 +1522,10 @@ After fixing the issues you can unblock the worker at
                 if old_value != new_value:
                     info = "Check_results: task {}/{} pentanomial value {} results mismatch: {}/{}".format(
                         run_id, task_id, i, old_value, new_value
+                    )
+                    self.actiondb.log_message(
+                        username="fishtest.system",
+                        message=info,
                     )
                     print(info, flush=True)
 
@@ -1564,11 +1577,15 @@ After fixing the issues you can unblock the worker at
         run["cores"] = 0
         run["workers"] = 0
         run["finished"] = True
-        valid = _validate(schema, run, "run")
-        if valid != "":
-            print(f"The run object {run_id} does not validate: {valid}", flush=True)
-            # We are not confident enough to enable this...
-            # assert False
+        try:
+            validate(schema, run, "run")
+        except ValidationError as e:
+            message = f"The run object {run_id} does not validate: {str(e)}"
+            print(message, flush=True)
+            self.actiondb.log_message(
+                username="fishtest.system",
+                message=message,
+            )
 
         self.buffer(run, True)
         # Publish the results of the run to the Fishcooking forum

--- a/server/fishtest/templates/actions.mak
+++ b/server/fishtest/templates/actions.mak
@@ -28,6 +28,7 @@
       <option value="upload_nn">Upload NN file</option>
       <option value="failed_task">Failed Tasks</option>
       <option value="crash_or_time">Crashes or Time losses</option>
+      <option value="log_message">Log Messages</option>
       <option value="dead_task" class="grayedoutoption">Dead Tasks</option>
       <option value="system_event" class="grayedoutoption">System Events</option>
     </select>

--- a/server/fishtest/userdb.py
+++ b/server/fishtest/userdb.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 
 from bson.objectid import ObjectId
 from pymongo import ASCENDING
-from vtjson import _validate, email, union, url
+from vtjson import ValidationError, email, union, url, validate
 
 schema = {
     "_id?": ObjectId,
@@ -24,10 +24,11 @@ DEFAULT_MACHINE_LIMIT = 16
 
 
 def validate_user(user):
-    valid = _validate(schema, user, "user")
-    if valid != "":
+    try:
+        validate(schema, user, "user")
+    except ValidationError as e:
         print(valid, flush=True)
-        assert False
+        raise
 
 
 class UserDb:

--- a/server/fishtest/workerdb.py
+++ b/server/fishtest/workerdb.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 
-from vtjson import _validate
+from vtjson import validate
 
 schema = {
     "worker_name": str,
@@ -40,7 +40,7 @@ class WorkerDb:
             "message": message,
             "last_updated": datetime.now(timezone.utc),
         }
-        assert _validate(schema, r, "worker") == ""
+        validate(schema, r, "worker")  # may throw exception
         self.workers.replace_one({"worker_name": worker_name}, r, upsert=True)
 
     def get_blocked_workers(self):


### PR DESCRIPTION
This may be used to give internal errors in the logic of Fishtest maximum visibility.

This action is currently used in two places:
    
- if a finished run does not validate;
    
- if `check_results` finds a discrepancy between the incrementally updated results and the computed results in a finished run.
    
Currently both errors are logged but otherwise they are treated silently.
    
Another application in the future might be to log certain worker errors which happen before a task is requested (e.g. failure to be able to run `cutechess-cli`).

While at it, replace all occurences of `_validate()`, which returns an error string on non-validation, by the more Pythonic `validate()`, which throws an exception instead.

Note: this PR conflicts (unavoidably) with #1876 . If the latter would be committed then this one has to be made into a draft, and vice versa.



