### PR TITLE
Detect and identify an AWS instance

### DIFF
--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 225, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "Hyq1aYXjX1uofUnSW9EGBXTQN0Jfjz7+LExmFxe6qLQEX1w8vxFQOpWTrRV4YZZz", "games.py": "7szyHwmVhZxkiiEjEOXjCrYnys7P5aAUBef5HFa2yh8FSBXggHGKAS2G0+Qq8KsP"}
+{"__version": 225, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "gCQhrCbWMzTWMBbo0ST2Fz+e7YUsaxya8AfmJUqFCxrTu+pbSmG94SMGVQ6dGPbx", "games.py": "7szyHwmVhZxkiiEjEOXjCrYnys7P5aAUBef5HFa2yh8FSBXggHGKAS2G0+Qq8KsP"}


### PR DESCRIPTION
This PR adds a suffix `(aws:<instance_type>:<instance_life_cycle>)`, for example `(aws:c4.8xlarge:spot)`, to the machine name when running on AWS (screenshots in the first comment).
    
Justification: 

- some workers may be tempted to use an under powered instance, possibly resulting in crashes and time losses. With this PR it should be possible to identify such workers. Note that the usual speed test cannot always be used reliably to eliminate such workers since some instance types (the `t-series`) have a burst mode: they will run at full speed for a while and then slow down dramatically.

- spot AWS instances may not have a stable UUID prefix. It it useful to be able to recognize this situation.

The documentation for the API used can be found here 
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
