### PR TITLE
Remove the fish.exit file after the worker has stopped.

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -28,7 +28,7 @@ db directly. However this information may be slightly outdated, depending
 on how frequently the main instance flushes its run cache.
 """
 
-WORKER_VERSION = 228
+WORKER_VERSION = 229
 
 """
 begin api_schema

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 228, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "fBx5K3aP5qJ1jRncVtWy0vzGgR6wokMWB+agEsZFAjOr3s8qJZL1JOc13rIiOGVk", "games.py": "C0yeQ5Oh8eyca64NntP+oetpWAjCvPSWdMyNCGSeS4o9yJN41L4SkL9rTx3z716m"}
+{"__version": 229, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "ZqWya/LcB5xq0sj+M/D1CApoBt0vGSTtBeaBLs3sFDEXezhfM0xdJCMeXlJZWN+5", "games.py": "C0yeQ5Oh8eyca64NntP+oetpWAjCvPSWdMyNCGSeS4o9yJN41L4SkL9rTx3z716m"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -55,7 +55,7 @@ from updater import update
 # Several packages are called "expression".
 # So we make sure to use the locally installed one.
 
-WORKER_VERSION = 228
+WORKER_VERSION = 229
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0
@@ -1661,6 +1661,9 @@ def worker():
         else:
             clear_binaries = False
             delay = INITIAL_RETRY_TIME
+
+    if fish_exit:
+        (worker_dir / "fish.exit").unlink()
 
     print("Waiting for the heartbeat thread to finish...")
     heartbeat_thread.join(THREAD_JOIN_TIMEOUT)


### PR DESCRIPTION
It seems more useful that way...