### PR TITLE
Don't hide "non-tested" nets for logged out users

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -482,12 +482,8 @@ class RunDb:
     def increment_nn_downloads(self, name):
         self.nndb.update_one({"name": name}, {"$inc": {"downloads": 1}})
 
-    def get_nns(
-        self, user_id, user="", network_name="", master_only=False, limit=0, skip=0
-    ):
+    def get_nns(self, user="", network_name="", master_only=False, limit=0, skip=0):
         q = {}
-        if user_id is None:
-            q["first_test"] = {"$exists": "true"}
         if user:
             q["user"] = {"$regex": ".*{}.*".format(user), "$options": "i"}
         if network_name:

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -413,7 +413,6 @@ def signup(request):
 
 @view_config(route_name="nns", renderer="nns.mak")
 def nns(request):
-    user_id = request.authenticated_userid
     user = request.params.get("user", "")
     network_name = request.params.get("network_name", "")
     master_only = request.params.get("master_only", False)
@@ -423,7 +422,6 @@ def nns(request):
     page_size = 25
 
     nns, num_nns = request.rundb.get_nns(
-        user_id=user_id,
         user=user,
         network_name=network_name,
         master_only=master_only,


### PR DESCRIPTION
there is no reason to hide them on the first place, and practice shows it's not the ideal thing let alone the net is still available so this is a fake frontend guard.

A follow up fix should be, website server changes after dual net, since the master net is not marked as tested for now.