### PR TITLE
Modifying the "Reduce ITP with number of active tests per user"

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -869,7 +869,7 @@ class RunDb:
                 itp *= bonus
 
         # Malus for too many active runs
-        itp *= 36.0 / (36.0 + count * count)
+        itp *= 64.0 / (64.0 + count * count)
 
         run["args"]["itp"] = itp
 


### PR DESCRIPTION
Closed it when fishtest was inactive, now re-opened it.

Reasons for this change:

Support for Active Developers:

Penalizing active developers with stringent bounds may discourage contributions. The proposed change ensures a more lenient approach, fostering a supportive environment for developers.

Balancing Act:

The adjustment strikes a balance between encouraging active testing and maintaining reasonable control over the number of tests. It provides a smoother reduction in itp as the number of active tests increases, offering a fair compromise.

Community Feedback:

I suggest seeking feedback from other devs on this proposed change. Open discussions can provide valuable insights and help in refining the formula to better suit the collective needs.