### PR TITLE
Benches both engines prior to raise a RunException

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -31,7 +31,7 @@ However, keep in mind that this information might be slightly outdated.
 This depends on how frequently the main instance flushes its `run_cache`.
 """
 
-WORKER_VERSION = 230
+WORKER_VERSION = 231
 
 """
 begin api_schema

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 230, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "2Z0LG7EAR0cmOY7yHDDsynebLO8yXmhwaBqjTAJpDDZlumO5o2xYMxglfCRg1/Bg", "games.py": "TzWMwq9hBmAHB0C7JAOvsI+pBvttQiPC4ul5FsOzozJ9lmZl/NutFbvWk8sobJr8"}
+{"__version": 231, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "2KAqGI1R7kyMS2UERiOSahOiFt9BGJN9bYMw2gvk4KV1/bmehqE9/2HrCdpK9R/K", "games.py": "hycICoWnfy6irO0N0w/vmFJBDXcwCECTVxX8PvGvm0TqxPXRbdCHxfr7iVLo5jC9"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -55,7 +55,7 @@ from updater import update
 # Several packages are called "expression".
 # So we make sure to use the locally installed one.
 
-WORKER_VERSION = 230
+WORKER_VERSION = 231
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0


### PR DESCRIPTION
This strategy ensures that the Events Log receives detailed information,
which assists in identifying the root cause of the issue.
Possible causes could range from an erroneous bench entry on the Fishtest
new run page, a malfunctioning engine, to a worker misconfiguration,
among others.

A WorkerException is still raised immediately.

closes https://github.com/official-stockfish/fishtest/issues/1897

Thanks to @peregrineshahin and @Disservin for bringing this issue to light.

Raise worker version to 231 (also server side)