### PR TITLE
Restrict SPSA C values to be greater than 2

### DIFF
--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -773,8 +773,8 @@ def parse_spsa_params(raw, spsa):
             continue
         if len(chunks) != 6:
             raise Exception("The line {} does not have 6 entries".format(chunks))
-        if float(chunks[4]) < 2:
-            raise Exception("The tuner requires c values greater than 2")
+        if float(chunks[4]) < 1:
+            raise Exception("The tuner requires c values greater than 1")
         param = {
             "name": chunks[0],
             "start": float(chunks[1]),

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -772,7 +772,9 @@ def parse_spsa_params(raw, spsa):
         if len(chunks) == 1 and chunks[0] == "":  # blank line
             continue
         if len(chunks) != 6:
-            raise Exception("the line {} does not have 6 entries".format(chunks))
+            raise Exception("The line {} does not have 6 entries".format(chunks))
+        if float(chunks[4]) < 2:
+            raise Exception("The tuner requires c values greater than 2")
         param = {
             "name": chunks[0],
             "start": float(chunks[1]),

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -774,7 +774,7 @@ def parse_spsa_params(raw, spsa):
         if len(chunks) != 6:
             raise Exception("The line {} does not have 6 entries".format(chunks))
         if float(chunks[4]) < 1:
-            raise Exception("The tuner requires c values greater than 1")
+            raise Exception("The tuner requires c values greater than or equal to 1")
         param = {
             "name": chunks[0],
             "start": float(chunks[1]),

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -773,8 +773,8 @@ def parse_spsa_params(raw, spsa):
             continue
         if len(chunks) != 6:
             raise Exception("The line {} does not have 6 entries".format(chunks))
-        if float(chunks[4]) < 1:
-            raise Exception("The tuner requires c values greater than or equal to 1")
+        if float(chunks[4]) < 2:
+            raise Exception("The tuner requires c values greater than or equal to 2")
         param = {
             "name": chunks[0],
             "start": float(chunks[1]),

--- a/worker/games.py
+++ b/worker/games.py
@@ -1091,7 +1091,7 @@ def launch_cutechess(
         cmd[:idx]
         + [
             "option.{}={}".format(
-                x["name"], int(x["value"])
+                x["name"], math.floor(x["value"])
             )
             for x in w_params
         ]
@@ -1102,7 +1102,7 @@ def launch_cutechess(
         cmd[:idx]
         + [
             "option.{}={}".format(
-                x["name"], int(x["value"])
+                x["name"], math.floor(x["value"])
             )
             for x in b_params
         ]

--- a/worker/games.py
+++ b/worker/games.py
@@ -1091,7 +1091,7 @@ def launch_cutechess(
         cmd[:idx]
         + [
             "option.{}={}".format(
-                x["name"], x["value"]
+                x["name"], int(x["value"])
             )
             for x in w_params
         ]
@@ -1102,7 +1102,7 @@ def launch_cutechess(
         cmd[:idx]
         + [
             "option.{}={}".format(
-                x["name"], x["value"]
+                x["name"], int(x["value"])
             )
             for x in b_params
         ]

--- a/worker/games.py
+++ b/worker/games.py
@@ -1091,7 +1091,7 @@ def launch_cutechess(
         cmd[:idx]
         + [
             "option.{}={}".format(
-                x["name"], math.floor(x["value"])
+                x["name"], math.floor(x["value"] + random.uniform(0, 1))
             )
             for x in w_params
         ]
@@ -1102,7 +1102,7 @@ def launch_cutechess(
         cmd[:idx]
         + [
             "option.{}={}".format(
-                x["name"], math.floor(x["value"])
+                x["name"], math.floor(x["value"] + random.uniform(0, 1))
             )
             for x in b_params
         ]

--- a/worker/games.py
+++ b/worker/games.py
@@ -1091,7 +1091,7 @@ def launch_cutechess(
         cmd[:idx]
         + [
             "option.{}={}".format(
-                x["name"], math.floor(x["value"] + random.uniform(0, 1))
+                x["name"], x["value"]
             )
             for x in w_params
         ]
@@ -1102,7 +1102,7 @@ def launch_cutechess(
         cmd[:idx]
         + [
             "option.{}={}".format(
-                x["name"], math.floor(x["value"] + random.uniform(0, 1))
+                x["name"], x["value"]
             )
             for x in b_params
         ]


### PR DESCRIPTION
Referring to https://github.com/official-stockfish/fishtest/issues/1907#issuecomment-1974860493

I have seen multiple tunes with c < 2, some even below 0.5. There is no reason to ever tune with the same parameter value across the interval (no derivative), the evolution of a parameter can be reduced by modifying the r value instead.

Moreover, there seems to be a misinterpretation in some devs that low c values are ok because 'stochastic rounding' will handle it, without having any understanding of how the underlying algorithm is actually working. This is not surprisingly given that this formula is not mentioned in any wiki.

This PR will expose to the dev clearly that certain c values have no effect. They can combine multiplying up the value for the tune with adjusting the r value to tune more effectively if they wish. This should be controlled on the dev side rather than within fishtest.