### PR TITLE
consistent "LTC:" addition

### DIFF
--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -350,12 +350,14 @@ def get_tc_ratio(tc, threads=1, base="10+0.1"):
     return threads * estimate_game_duration(tc) / estimate_game_duration(base)
 
 
-def is_active_sprt_ltc(run):
+def is_sprt_ltc_data(args):
     return (
-        not run["finished"]
-        and "sprt" in run["args"]
-        and get_tc_ratio(run["args"]["tc"], run["args"]["threads"]) > 4
+        "sprt" in args and get_tc_ratio(args["tc"], args["threads"]) > 4
     )  # SMP-STC ratio is 4
+
+
+def is_active_sprt_ltc(run):
+    return not run["finished"] and is_sprt_ltc_data(run["args"])
 
 
 def format_date(date):

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -22,6 +22,7 @@ from fishtest.util import (
     get_hash,
     get_tc_ratio,
     github_repo_valid,
+    is_sprt_ltc_data,
     password_strength,
     update_residuals,
 )
@@ -965,9 +966,7 @@ def validate_form(request):
                     "This commit has no signature: please supply it manually."
                 )
         if len(data["info"]) == 0:
-            data["info"] = (
-                "" if re.match(r"^[012]?[0-9][^0-9].*", data["tc"]) else "LTC: "
-            ) + strip_message(c["commit"]["message"])
+            data["info"] = strip_message(c["commit"]["message"])
 
     # Check that the book exists in the official books repo
     if len(data["book"]) > 0:
@@ -1194,6 +1193,8 @@ def tests_run(request):
     if request.method == "POST":
         try:
             data = validate_form(request)
+            if is_sprt_ltc_data(data):
+                data["info"] = "LTC: " + data["info"]
             run_id = request.rundb.new_run(**data)
             run = request.rundb.get_run(run_id)
             request.actiondb.new_run(


### PR DESCRIPTION
the addition of "LTC:" has been overwritten by the green highlighting feature which leaves one source of truth to edit it if needed.

currently this looks old way to catch LTCs, here is a conflict of green highlighting and the added text https://tests.stockfishchess.org/tests/view/65f0ca4f0ec64f0526c46a67