### PR TITLE
Mitigate Python 3.12 Shutdown RuntimeError

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -361,8 +361,16 @@ class RunDb:
                 return None
 
     def start_timer(self):
-        self.timer = threading.Timer(1.0, self.flush_buffers)
-        self.timer.start()
+        try:
+            self.timer = threading.Timer(1.0, self.flush_buffers)
+            self.timer.start()
+        except RuntimeError as e:
+            # Mitigation for a 3.12 bug during the interpreter shutdown, see:
+            # - issue https://github.com/python/cpython/pull/104826
+            # - bugfix https://github.com/python/cpython/pull/117029
+            # With python 3.12.3 the try except block could be potentially removed.
+            if "interpreter shutdown" not in str(e):
+                raise
 
     def buffer(self, run, flush):
         with self.run_cache_lock:


### PR DESCRIPTION
Python 3.12 introduced a bug during the interpreter shutdown, see:
- issue https://github.com/python/cpython/pull/104826
- bugfix https://github.com/python/cpython/pull/117029

With Python 3.12.3, this change could potentially be reverted (after testing).