### PR TITLE
Versioning the run object.

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -17,7 +17,7 @@ import fishtest.stats.stat_util
 from bson.binary import Binary
 from bson.objectid import ObjectId
 from fishtest.actiondb import ActionDb
-from fishtest.schemas import nn_schema, runs_schema
+from fishtest.schemas import RUN_VERSION, nn_schema, runs_schema
 from fishtest.stats.stat_util import SPRT_elo
 from fishtest.userdb import UserDb
 from fishtest.util import (
@@ -189,6 +189,7 @@ class RunDb:
         if tc_base:
             tc_base = float(tc_base.group(1))
         new_run = {
+            "version": RUN_VERSION,
             "args": run_args,
             "start_time": start_time,
             "last_updated": start_time,
@@ -1355,11 +1356,11 @@ After fixing the issues you can unblock the worker at
         except ValidationError as e:
             message = f"The run object {run_id} does not validate: {str(e)}"
             print(message, flush=True)
-            self.actiondb.log_message(
-                username="fishtest.system",
-                message=message,
-            )
-
+            if "version" in run and run["version"] >= RUN_VERSION:
+                self.actiondb.log_message(
+                    username="fishtest.system",
+                    message=message,
+                )
         self.buffer(run, True)
         # Publish the results of the run to the Fishcooking forum
         post_in_fishcooking_results(run)

--- a/server/fishtest/schemas.py
+++ b/server/fishtest/schemas.py
@@ -386,9 +386,17 @@ def final_results_must_match(run):
 # it would also be useful to have a "universal schema"
 # that matches all the runs in the db.
 
+# Please increment this if the format of the run schema
+# changes. This will suppress spurious event log messages
+# about non-validation of runs created with the prior
+# schema.
+
+RUN_VERSION = 0
+
 runs_schema = intersect(
     {
         "_id?": ObjectId,
+        "version": uint,
         "start_time": datetime,
         "last_updated": datetime,
         "tc_base": unumber,


### PR DESCRIPTION
Currently version 0!

This is a quick go at versioning the run object to suppress spurious event log messages about validation errors for runs that were created before the schema changed.

Not yet tested but the code is fairly trivial.

This is in connection with the discussion at #1927 