### PR TITLE
Improve the action schema.

### DIFF
--- a/server/fishtest/actiondb.py
+++ b/server/fishtest/actiondb.py
@@ -218,8 +218,10 @@ class ActionDb:
         action["time"] = datetime.now(timezone.utc).timestamp()
         try:
             validate(action_schema, action, "action")
-        except ValidationError:
-            message = f"Internal Error. Request {str(action)} does not validate"
+        except ValidationError as e:
+            message = (
+                f"Internal Error. Request {str(action)} does not validate: {str(e)}"
+            )
             print(message, flush=True)
             self.log_message(
                 username="fishtest.system",


### PR DESCRIPTION
The new schema is functionally equivalent to the old schema but the non-validation messages are much better.

Validating
```python
{"action": "failed_task", "message": "It's going well!"}
```
against the old schema may yield (it is not deterministic)
```
action['worker'] is missing and action['worker'] is missing and action['worker'] is missing and action['action']
(value:'failed_task') is not equal to 'system_event' and action['action'] (value:'failed_task') is not equal to 'new_run' and action['action'] (value:'failed_task') is not equal to 'upload_nn' and action['action'] (value:'failed_task') is not equal to 'modify_run' and action['action'] (value:'failed_task') is not equal to 'delete_run' and action['action']
(value:'failed_task') is not equal to 'stop_run' and action['action'] (value:'failed_task') is not equal to 'finished_run' and action['action'] (value:'failed_task') is not equal to 'approve_run' and action['action'] (value:'failed_task') is not equal to 'purge_run' and action['user'] is missing and action['user'] is missing and action['worker'] is missing and action['action'] (value:'failed_task') is not equal to 'log_message'
```
whereas the new schema gives
```
action['worker'] is missing
```
Requires upgrading the vtjson package.