### PR TITLE
Fix a bug in diffs

### DIFF
--- a/server/fishtest/static/js/application.js
+++ b/server/fishtest/static/js/application.js
@@ -58,7 +58,7 @@ function protectForms() {
   });
 }
 
-// Gets from the bowser the value of a saved cookie
+// Gets from the browser the value of a saved cookie
 function getCookie(cookieName) {
   return document.cookie
     .split(";")


### PR DESCRIPTION
API limit rate shows `no diff available` then saves that in session storage, this is not intended. this prevents such text to be saved in session storage. TBH 60 requests / hour is not what I expected from GitHub, although rewriting the diff code to the server-side might help a bit it's not the best idea because the server does a lot of requests to GitHub anyways. limit rate could be easily solved once GitHub Auth is introduced (soonTM?).