### PR TITLE
Revert "Mitigate Python 3.12 Shutdown RuntimeError"

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -366,16 +366,8 @@ class RunDb:
                 return None
 
     def start_timer(self):
-        try:
-            self.timer = threading.Timer(1.0, self.flush_buffers)
-            self.timer.start()
-        except RuntimeError as e:
-            # Mitigation for a 3.12 bug during the interpreter shutdown, see:
-            # - issue https://github.com/python/cpython/pull/104826
-            # - bugfix https://github.com/python/cpython/pull/117029
-            # With python 3.12.3 the try except block could be potentially removed.
-            if "interpreter shutdown" not in str(e):
-                raise
+        self.timer = threading.Timer(1.0, self.flush_buffers)
+        self.timer.start()
 
     def buffer(self, run, flush):
         with self.run_cache_lock:


### PR DESCRIPTION
Reverts official-stockfish/fishtest#1925

PROD updated to python 3.12.3 that has the bugfix https://github.com/python/cpython/pull/117029
```python
# test_interpreter_shutdown.py
import threading, time

def main():
    threading.Thread(target=bloop).start()

def bloop():
    time.sleep(0.5)
    threading.Thread(target=print, args=("new thread running",)).start()

main()
```

- python 3.12.3:
```
$ python3 test_interpreter_shutdown.py
new thread running
```

- python 3.12.2:
```
$ python3 test_interpreter_shutdown.py
Exception in thread Thread-1 (bloop):
Traceback (most recent call last):
  File "/home/fishtest/.pyenv/versions/3.12.2/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
    self.run()
  File "/home/fishtest/.pyenv/versions/3.12.2/lib/python3.12/threading.py", line 1010, in run
    self._target(*self._args, **self._kwargs)
  File "/home/fishtest/test_interpreter_shutdown.py", line 8, in bloop
    threading.Thread(target=print, args=("new thread running",)).start()
  File "/home/fishtest/.pyenv/versions/3.12.2/lib/python3.12/threading.py", line 992, in start
    _start_new_thread(self._bootstrap, ())
RuntimeError: can't create new thread at interpreter shutdown
```