### PR TITLE
Make PyMongo timezone-aware

### DIFF
--- a/server/fishtest/schemas.py
+++ b/server/fishtest/schemas.py
@@ -82,9 +82,8 @@ worker_schema = {
 
 
 def first_test_before_last(x):
-    # Pymongo is not timezone aware. Assume dates are UTC.
-    f = x["first_test"]["date"].replace(tzinfo=timezone.utc)
-    l = x["last_test"]["date"].replace(tzinfo=timezone.utc)
+    f = x["first_test"]["date"]
+    l = x["last_test"]["date"]
     if f <= l:
         return True
     else:

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -425,11 +425,11 @@ def post_in_fishcooking_results(run):
 
 
 def diff_date(date):
-    utc_date = date.replace(tzinfo=timezone.utc)
-    if utc_date != datetime.min.replace(tzinfo=timezone.utc):
-        diff = datetime.now(timezone.utc) - utc_date
-    else:
-        diff = timedelta.max
+    diff = (
+        datetime.now(timezone.utc) - date
+        if date != datetime.min.replace(tzinfo=timezone.utc)
+        else timedelta.max
+    )
     return diff
 
 

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -837,10 +837,7 @@ def validate_modify(request, run):
         raise home(request)
 
     now = datetime.now(timezone.utc)
-    if (
-        "start_time" not in run
-        or (now - run["start_time"].replace(tzinfo=timezone.utc)).days > 30
-    ):
+    if "start_time" not in run or (now - run["start_time"]).days > 30:
         request.session.flash("Run too old to be modified", "error")
         raise home(request)
 
@@ -1565,8 +1562,8 @@ def tests_view(request):
         if task["active"]:
             active += 1
             cores += task["worker_info"]["concurrency"]
-        last_updated = task.get("last_updated", datetime.min).replace(
-            tzinfo=timezone.utc
+        last_updated = task.get(
+            "last_updated", datetime.min.replace(tzinfo=timezone.utc)
         )
         task["last_updated"] = last_updated
 

--- a/server/tests/test_nn.py
+++ b/server/tests/test_nn.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 
 from util import get_rundb
 from vtjson import ValidationError
@@ -15,9 +15,9 @@ class TestNN(unittest.TestCase):
         self.rundb = get_rundb()
         self.name = "nn-0000000000a0.nnue"
         self.user = "user00"
-        self.first_test = datetime(2024, 1, 1)
-        self.last_test = datetime(2024, 3, 24)
-        self.last_test_old = datetime(2023, 3, 24)
+        self.first_test = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        self.last_test = datetime(2024, 3, 24, tzinfo=timezone.utc)
+        self.last_test_old = datetime(2023, 3, 24, tzinfo=timezone.utc)
         self.run_id = "64e74776a170cb1f26fa3930"
 
     def tearDown(self):

--- a/server/utils/purge_pgn.py
+++ b/server/utils/purge_pgn.py
@@ -23,8 +23,8 @@ def purge_pgn(rundb, finished, deleted, days):
             not deleted
             and finished
             and tc_regex.match(run["args"]["tc"])
-            and run["last_updated"].replace(tzinfo=timezone.utc) > cutoff_date_ltc
-        ) or run["last_updated"].replace(tzinfo=timezone.utc) > cutoff_date
+            and run["last_updated"] > cutoff_date_ltc
+        ) or run["last_updated"] > cutoff_date
 
         if keep:
             kept_runs += 1


### PR DESCRIPTION
https://pymongo.readthedocs.io/en/stable/examples/datetimes.html#reading-time

"By default all `datetime.datetime` objects returned by PyMongo will be naive but reflect UTC (i.e. the time as stored in MongoDB). By setting the `tz_aware` option on `CodecOptions`, `datetime.datetime` objects will be timezone-aware and have a `tzinfo` property that reflects the UTC timezone."