### PR TITLE
Retrieve cached run for the tasks view

### DIFF
--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -1411,10 +1411,7 @@ def tests_stats(request):
 
 @view_config(route_name="tests_tasks", renderer="tasks.mak")
 def tests_tasks(request):
-    r_id = request.matchdict["id"]
-    run = request.rundb.runs.find_one(
-        {"_id": ObjectId(r_id)}, {"tasks": 1, "bad_tasks": 1, "results": 1, "args": 1}
-    )
+    run = request.rundb.get_run(request.matchdict["id"])
     if run is None:
         raise exception_response(404)
 


### PR DESCRIPTION
Address the issue of outdated active test data in the run retrieved from the database, which is particularly noticeable in the chi2 residuals.

Fixed the Nginx config to serve the route /tests/tasks from the main Fishtest instance.