### PR TITLE
Use macos13 runner in CI

### DIFF
--- a/.github/workflows/worker_posix.yaml
+++ b/.github/workflows/worker_posix.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest]
+        os: [ubuntu-20.04, macos-13]
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     defaults:
       run:


### PR DESCRIPTION
This is the latest runner version supporting python 3.6