### PR TITLE
Implement bulk streaming of tasks PGNs for a run

### DIFF
--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -15,6 +15,24 @@ from zxcvbn import zxcvbn
 FISH_URL = "https://tests.stockfishchess.org/tests/view/"
 
 
+class GeneratorAsFileReader:
+    def __init__(self, generator):
+        self.generator = generator
+        self.buffer = b""
+
+    def read(self, size=-1):
+        while size < 0 or len(self.buffer) < size:
+            try:
+                self.buffer += next(self.generator)
+            except StopIteration:
+                break
+        result, self.buffer = self.buffer[:size], self.buffer[size:]
+        return result
+
+    def close(self):
+        pass  # No cleanup needed, but method is required
+
+
 def hex_print(s):
     return hashlib.md5(str(s).encode("utf-8")).digest().hex()
 


### PR DESCRIPTION
This commit adds a feature that streams PGNs of a run, significantly reducing
the server's CPU/RAM usage. The API now returns a gzipped PGN, constructed by
chaining all the run's gzipped PGNs, which is streamed to the client.

Key changes:
1. update 'api_download_run_pgns' in api.py, which handles the request for
downloading the PGN of the run. It fetches the PGNs using the
'get_run_pgns' method from the RunDb class, and returns a gzipped response
    ```
    wget https://test.stockfishchess.org/api/run_pgns/<run_id>.pgn.gz
    ```
2. add 'GeneratorAsFileReader' class in util.py that provides a file-like
interface for a generator, enabling chanked reading
3. modify the 'get_run_pgns' method in rundb.py to return a
'GeneratorAsFileReader' object that yields each gzipped PGN file for the run

Note: the `gunzip on;` directive must be removed from the nginx configuration.

Improvement suggested by @peregrineshahin