### PR TITLE
Fix SPSA iteration mismatch

### DIFF
--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -831,6 +831,13 @@ def validate_modify(request, run):
         )
         raise home(request)
 
+    if "spsa" in run["args"] and num_games != run["args"]["num_games"]:
+        request.session.flash(
+            "Unable to modify number of games for SPSA tests, SPSA hyperparams are based off the initial number of games",
+            "error",
+        )
+        raise home(request)
+
     max_games = 3200000
     if num_games > max_games:
         request.session.flash("Number of games must be <= " + str(max_games), "error")


### PR DESCRIPTION
after updating the number of games the iterations completion can be more than 100% 75k/60k this is because SPSA num of games should not be modifiable after creation
![image (1)](https://github.com/official-stockfish/fishtest/assets/41402573/ccc23cab-1457-49b3-953f-95f76bf4aa35)
See Also: https://discord.com/channels/435943710472011776/900771437177094156/1234042155346169937
