### PR TITLE
Drop "Content-Encoding" header for run PGNs

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -542,7 +542,6 @@ class ApiView(object):
         response = Response(content_type="application/gzip")
         response.app_iter = FileIter(pgns_reader)
         response.headers["Content-Disposition"] = f'attachment; filename="{pgns_name}"'
-        response.headers["Content-Encoding"] = "gzip"
         response.headers["Content-Length"] = str(total_size)
         return response
 


### PR DESCRIPTION
A client able to decompress on the fly the gzip content stops the download after extracting the first PGN (it expectes to download one file) ignoring the "Content-Length" header.

Drop the "Content-Encoding" header to complete the download of all the PGNs.