### PR TITLE
use the custom `alertError` for errors we want to show to the user

### DIFF
--- a/server/fishtest/static/js/calc.js
+++ b/server/fishtest/static/js/calc.js
@@ -87,7 +87,13 @@ function drawCharts(resize) {
     // do not show a stale alert with a resize
     // and use last valid sprt to draw chart
     if (!resize || !validSprt) {
-      alert(error);
+      if (alertError) {
+        // if a global custom alertError is defined when using this package
+        alertError(error);
+      } else {
+        alert(error);
+      }
+
       return;
     } else sprt = validSprt;
   } else validSprt = sprt;

--- a/server/fishtest/templates/tests_run.mak
+++ b/server/fishtest/templates/tests_run.mak
@@ -1002,14 +1002,14 @@
     const params = document.getElementById('spsa_raw_params').value;
     let s = fishtestToSpsa(params);
     if (s === null) {
-      alert("Unable to parse spsa parameters.");
+      alertError("Unable to parse spsa parameters.");
       return false;
     }
     /* estimate the draw ratio */
     const tc = document.getElementById('tc').value;
     const dr = drawRatio(tc);
     if (dr === null) {
-      alert("Unable to parse time control.");
+      alertError("Unable to parse time control.");
       return false;
     }
     s.draw_ratio = dr;


### PR DESCRIPTION
This removes the old system-dependent `alert()` usage