### PR TITLE
Do not update residuals in tests_view.

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -1306,6 +1306,8 @@ After fixing the issues you can unblock the worker at
             # done by stop_run.
             ret = {"task_alive": False}
         else:
+            if not task["active"]:
+                update_residuals(run["tasks"])
             self.buffer(run, False)
             ret = {"task_alive": task["active"]}
 
@@ -1322,6 +1324,7 @@ After fixing the issues you can unblock the worker at
         # Mark the task as inactive.
         task["active"] = False
         self.handle_crash_or_time(run, task_id)
+        update_residuals(run["tasks"])
         self.buffer(run, False)
         print(
             "Failed_task: failure for: https://tests.stockfishchess.org/tests/view/{}, "
@@ -1347,6 +1350,7 @@ After fixing the issues you can unblock the worker at
         """
         self.clear_params(run_id)  # spsa stuff
         run = self.get_run(run_id)
+        update_residuals(run["tasks"])
         for task in run["tasks"]:
             task["active"] = False
         results = run["results"]

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -20,7 +20,6 @@ from fishtest.util import (
     get_hash,
     get_tc_ratio,
     password_strength,
-    update_residuals,
 )
 from pyramid.httpexceptions import HTTPFound, exception_response
 from pyramid.security import forget, remember
@@ -1565,7 +1564,6 @@ def tests_view(request):
         task.setdefault("last_updated", datetime.min.replace(tzinfo=timezone.utc))
 
     chi2 = get_chi2(run["tasks"])
-    update_residuals(run["tasks"], cached_chi2=chi2)
 
     try:
         show_task = int(request.params.get("show_task", -1))


### PR DESCRIPTION
tests_view is a GET request. It should not change the server state.

We now update the residuals
- after finishing a task;
- after a task failed;
- when a run is finished.

IMHO the former lack of regular updates of the residuals was also the cause of the issue #1948.

Not seriously tested (I lack the resources to generate enough tasks to have meaningful residuals).

