### PR TITLE
Don't save the residuals and their colors in the db.

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -436,7 +436,7 @@ class UserApi(GenericApi):
             task["last_updated"] = str(task["last_updated"])
         if "residual" in task:
             # json does not know about infinity
-            if task["residual"] == float("inf"):
+            if task.get("residual", None) == float("inf"):
                 task["residual"] = "inf"
         return task
 

--- a/server/fishtest/schemas.py
+++ b/server/fishtest/schemas.py
@@ -62,6 +62,7 @@ pgn_file = glob("*.pgn", name="pgn_file")
 even = div(2, name="even")
 datetime_utc = intersect(datetime, fields({"tzinfo": timezone.utc}))
 gzip_data = magic("application/gzip", name="gzip_data")
+residual_color = set_name(union("green", "yellow", "red"), "residual_color")
 
 uint = intersect(int, ge(0))
 suint = intersect(int, gt(0))
@@ -640,7 +641,7 @@ valid_aggregated_data = intersect(
 # about non-validation of runs created with the prior
 # schema.
 
-RUN_VERSION = 6
+RUN_VERSION = 7
 
 runs_schema = intersect(
     {
@@ -762,8 +763,6 @@ runs_schema = intersect(
                     "active": bool,
                     "last_updated": datetime_utc,
                     "start": uint,
-                    "residual?": number,
-                    "residual_color?": str,
                     "bad?": True,
                     "stats": results_schema,
                     "worker_info": worker_info_schema_runs,
@@ -772,14 +771,14 @@ runs_schema = intersect(
             ),
             ...,
         ],
-        "bad_tasks?": [
+        "bad_tasks": [
             {
                 "num_games": intersect(uint, even),
                 "active": False,
                 "last_updated": datetime_utc,
                 "start": uint,
                 "residual": number,
-                "residual_color": str,
+                "residual_color": residual_color,
                 "bad": True,
                 "task_id": task_id,
                 "stats": results_schema,

--- a/server/fishtest/templates/tasks.mak
+++ b/server/fishtest/templates/tasks.mak
@@ -1,5 +1,5 @@
 <%!
-  from fishtest.util import worker_name
+  from fishtest.util import worker_name, display_residual
 %>
 
 % for idx, task in enumerate(run['tasks'] + run.get('bad_tasks', [])):
@@ -70,9 +70,12 @@
     <td>${stats.get('time_losses', '-')}</td>
 
     % if 'spsa' not in run['args']:
-      % if 'residual' in task and task['residual']!=float("inf"):
-        <td style="background-color:${task['residual_color']}">
-          ${f"{task['residual']:.3f}"}
+      <%
+        d=display_residual(task, chi2)
+      %>
+      % if d['residual']!=float("inf"):
+        <td style="background-color:${d['display_color']}">
+          ${f"{d['residual']:.3f}"}
         </td>
       % else:
         <td>-</td>

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -23,7 +23,6 @@ from fishtest.util import (
     github_repo_valid,
     is_sprt_ltc_data,
     password_strength,
-    update_residuals,
 )
 from pyramid.httpexceptions import HTTPFound, HTTPNotFound
 from pyramid.security import forget, remember
@@ -1461,6 +1460,7 @@ def tests_tasks(request):
     run = request.rundb.get_run(request.matchdict["id"])
     if run is None:
         raise HTTPNotFound()
+    chi2 = get_chi2(run["tasks"])
 
     try:
         show_task = int(request.params.get("show_task", -1))
@@ -1473,6 +1473,7 @@ def tests_tasks(request):
         "run": run,
         "approver": request.has_permission("approve_run"),
         "show_task": show_task,
+        "chi2": chi2,
     }
 
 
@@ -1603,7 +1604,6 @@ def tests_view(request):
             cores += task["worker_info"]["concurrency"]
 
     chi2 = get_chi2(run["tasks"])
-    update_residuals(run["tasks"], cached_chi2=chi2)
 
     try:
         show_task = int(request.params.get("show_task", -1))


### PR DESCRIPTION
The main reason for this PR is that currently the residuals are updated in `tests_view`. This is *wrong*. `tests_view` is a GET request. It is not allowed to change the server state. 

So if we want updated residuals then we need to update them during POST requests, such as `update_task` and `failed_task`. However this may be CPU intensive if a fleet of workers disconnects. We could throttle the updates but this requires some extra state that needs to be maintained (the time of  the last update).

So the alternative is to compute the residuals on the fly when they are displayed. This is what this PR does. This solves for example the issue #1948. It should now again be possible to serve the tasks from a secondary instance.

Computing residuals on the fly is not possible for bad tasks. So for bad tasks we record the residual and its color from the time they became bad. However the color is saved symbolically as `green`, `yellow`, `red`, instead of as an actual hex-code.


This PR is almost totally untested because
- testing the purging code is tricky;
- I lack the resources to generate tasks with meaningful residual