### PR TITLE
Log long worker names when rejecting a duplicate worker name.

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -869,9 +869,11 @@ After fixing the issues you can unblock the worker at
                 last_update = (now - task["last_updated"]).seconds
                 # 120 = period of heartbeat in worker.
                 if last_update <= 120:
-                    error = 'Request_task: There is already a worker running with name "{}" which sent an update {} seconds ago'.format(
-                        my_name,
-                        last_update,
+                    task_name_long = worker_name(task["worker_info"])
+                    my_name_long = worker_name(worker_info)
+                    error = (
+                        f'Request_task: There is already a worker running with name "{task_name_long}" '
+                        f'which sent an update {last_update} seconds ago (my name is "{my_name_long}")'
                     )
                     print(error, flush=True)
                     return {"task_waiting": False, "error": error}


### PR DESCRIPTION
This is to debug sequences of rejections such as this one (see #1976)

Apr 24 22:26:50 tests.stockfishchess.org pserve[24847]: Request_task: There is already a worker running with name "ChessDBCN-11cores-ccd4f156" which sent an update 70 seconds ago
Apr 24 22:28:46 tests.stockfishchess.org pserve[24847]: Request_task: There is already a worker running with name "ChessDBCN-11cores-ccd4f156" which sent an update 50 seconds ago
Apr 24 22:29:42 tests.stockfishchess.org pserve[24847]: Request_task: There is already a worker running with name "ChessDBCN-11cores-ccd4f156" which sent an update 106 seconds ago
Apr 24 22:32:21 tests.stockfishchess.org pserve[24847]: Request_task: There is already a worker running with name "ChessDBCN-11cores-ccd4f156" which sent an update 70 seconds ago

I conjecture that this is a sequence of events where a worker connects, becomes incommunicado, and then blocks new connections for a while, until the cycle repeats. But we'll see.

The new message format is

Request_task: There is already a worker running with name "user00-4cores-dezuivel-86d6" which sent an update 64 seconds ago (my name is "user00-4cores-dezuivel-7d7c").