### PR TITLE
Enhance UX for creating tests.

### DIFF
--- a/server/fishtest/templates/tests_run.mak
+++ b/server/fishtest/templates/tests_run.mak
@@ -87,9 +87,7 @@
                         "options": "Hash=64",
                         "book": "${test_book}",
                         "stop_rule": "stop-rule-sprt",
-                        "bounds": "standard LTC",
-                        "base_branch": "${base_branch}",
-                        "base_signature": ${latest_bench}
+                        "bounds": "standard LTC"
                       }'>
                     <label class="list-group-item rounded-3" for="ltc_test" title="Long time control | Single-threaded">
                       LTC
@@ -107,9 +105,7 @@
                         "options": "Hash=64",
                         "book": "${test_book}",
                         "stop_rule": "stop-rule-sprt",
-                        "bounds": "standard STC",
-                        "base_branch": "${base_branch}",
-                        "base_signature": ${latest_bench}
+                        "bounds": "standard STC"
                       }'>
                     <label class="list-group-item rounded-3" for="stc_smp_test" title="Short time control | Multi-threaded">
                       STC SMP
@@ -127,9 +123,7 @@
                         "options": "Hash=256",
                         "book": "${test_book}",
                         "stop_rule": "stop-rule-sprt",
-                        "bounds": "standard LTC",
-                        "base_branch": "${base_branch}",
-                        "base_signature": ${latest_bench}
+                        "bounds": "standard LTC"
                       }'>
                     <label class="list-group-item rounded-3" for="ltc_smp_test" title="Long time control | Multi-threaded">
                       LTC SMP
@@ -147,9 +141,7 @@
                         "options": "Hash=192",
                         "book": "${test_book}",
                         "stop_rule": "stop-rule-sprt",
-                        "bounds": "standard STC",
-                        "base_branch": "${base_branch}",
-                        "base_signature": ${latest_bench}
+                        "bounds": "standard STC"
                       }'>
                     <label class="list-group-item rounded-3" for="vltc_test" title="Very long time control | Single-threaded">
                       VLTC
@@ -167,9 +159,7 @@
                         "options": "Hash=512",
                         "book": "${test_book}",
                         "stop_rule": "stop-rule-sprt",
-                        "bounds": "standard LTC",
-                        "base_branch": "${base_branch}",
-                        "base_signature": ${latest_bench}
+                        "bounds": "standard LTC"
                       }'>
                     <label class="list-group-item rounded-3" for="vltc_smp_test" title="Very long time control | Multi-threaded">
                       VLTC SMP
@@ -813,8 +803,13 @@
           if (test_signature) {
             document.getElementById("test-signature").value = test_signature;
           }
-          document.getElementById("base-branch").value = base_branch;
-          document.getElementById("base-signature").value = base_signature;
+          
+          if (base_branch) {
+            document.getElementById("base-branch").value = base_branch;
+          }
+          if (base_signature) {
+            document.getElementById("base-signature").value = base_signature;
+          }
         }
 
         if (name === "PT" || name === "PT SMP") {


### PR DESCRIPTION
This is a suggestion by @Vizvezdenec .. sometimes the user forgets that they need to pick the right TC before editing base branch and base signature, which if they did and then pick the wanted TC then the values they wrote/copied from another place will be overwritten, this solves this by marking `LTC, STC SMP, LTC SMP, VLTC, VLTC SMP` as `don't care`.