### PR TITLE
Set the request_task semaphore to one.

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -710,7 +710,7 @@ class RunDb:
 
     # Limit concurrent request_task
     task_lock = threading.Lock()
-    task_semaphore = threading.Semaphore(4)
+    task_semaphore = threading.Semaphore(1)
 
     task_time = 0
     task_runs = None


### PR DESCRIPTION
The current value of 5 is never hit according to the server logs, even with large fleets connecting.

With value 1 the semaphore behaves as a non-blocking lock. The server will never wait for `sync_request_task` to finish but instead informs the worker that no task is available.

Not tested.