### PR TITLE
Smarten Live Elo

### DIFF
--- a/server/fishtest/static/js/live_elo.js
+++ b/server/fishtest/static/js/live_elo.js
@@ -182,7 +182,29 @@ async function followLive(testId) {
 
   // Main worker
 
-  while (true) {
+  let isTabFocused = true;
+  let isVisibilityChange = true;
+
+  document.addEventListener("visibilitychange", function () {
+    isTabFocused = document.visibilityState === "visible";
+
+    // If the tab just becomes visible, update immediately
+    if (isVisibilityChange && isTabFocused) {
+      isVisibilityChange = false;
+      update();
+    }
+  });
+
+  async function mainWorker() {
+    while (true) {
+      if (isTabFocused) {
+        update();
+      }
+      await asyncSleep(20000);
+    }
+  }
+
+  async function update() {
     const timestamp = new Date().getTime();
     try {
       const m = await fetchJson("/api/get_elo/" + testId + "?" + timestamp);
@@ -191,6 +213,8 @@ async function followLive(testId) {
     } catch (e) {
       console.log("Network error: " + e);
     }
-    await asyncSleep(20000);
   }
+
+  // Start the worker
+  mainWorker();
 }


### PR DESCRIPTION
This avoids fetching each 20s tabs that are not focused/visible by the user, by making one tab update at a time for multiple Live Elo tabs. on the other hand updates immediately the new tab if it becomes the one in focus. Allowing for less load from the API with a lazy load approach.