### PR TITLE
Extend `get_run()` to support secondary instances

### DIFF
--- a/server/fishtest/templates/tests_run.mak
+++ b/server/fishtest/templates/tests_run.mak
@@ -803,7 +803,7 @@
           if (test_signature) {
             document.getElementById("test-signature").value = test_signature;
           }
-          
+
           if (base_branch) {
             document.getElementById("base-branch").value = base_branch;
           }


### PR DESCRIPTION
Simplify the coding of the APIs moving the logic of primary/secondary
instance in the RunDB class.
Drop old debug code.
