### PR TITLE
Proof of concept implementation of get_run via api (RFC).

### DIFF
--- a/server/fishtest/__init__.py
+++ b/server/fishtest/__init__.py
@@ -176,6 +176,7 @@ def main(global_config, **settings):
     config.add_route("api_get_elo", "/api/get_elo/{id}")
     config.add_route("api_actions", "/api/actions")
     config.add_route("api_calc_elo", "/api/calc_elo")
+    config.add_route("api_serialize_run", "/api/serialize_run/{id}")
 
     config.scan()
     return config.make_wsgi_app()

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -1,4 +1,6 @@
+import base64
 import copy
+import gzip
 import hashlib
 import math
 import re
@@ -7,9 +9,11 @@ from datetime import datetime, timedelta, timezone
 from functools import cache
 from random import uniform
 
+import bson
 import fishtest.stats.stat_util
 import numpy
 import scipy.stats
+from bson.codec_options import CodecOptions
 from email_validator import EmailNotValidError, caching_resolver, validate_email
 from zxcvbn import zxcvbn
 
@@ -779,3 +783,18 @@ class Scheduler:
             else:
                 self.__event.wait()
             self.__event.clear()
+
+
+def serialize(run):
+    b = bson.encode(run)
+    g = gzip.compress(b)
+    return g
+
+
+codec_options = CodecOptions(tz_aware=True, tzinfo=timezone.utc)
+
+
+def deserialize(g):
+    b = gzip.decompress(g)
+    run = bson.decode(b, codec_options=codec_options)
+    return run


### PR DESCRIPTION
With this PR `/api/serialize_run` hosted by the main instance can be invoked by a secondary instance to receive a copy of the run from the cache.

In this way there is never an issue that the run might not be up to date.

Sadly I don't know how feasible this is. A typical serialized run is 5.5k. Is this too much?

Note: `/api/serialize_run` restricts access to `localhost` over `http`. Some form of access control is necessary but it can also be done externally.

I have tested that the PR works. The deserialized runs pass validation (for this I needed to supply the `tz_aware` codec option to `bson.decode()`). 
