### PR TITLE
Validate run_id with ObjectId.is_valid in api_schema.

### DIFF
--- a/server/fishtest/schemas.py
+++ b/server/fishtest/schemas.py
@@ -37,7 +37,7 @@ from vtjson import (
     url,
 )
 
-run_id = regex(r"[a-f0-9]{24}", name="run_id")
+run_id = intersect(str, set_name(ObjectId.is_valid, "valid_object_id"))
 run_id_pgns = regex(r"[a-f0-9]{24}-(0|[1-9]\d*)", name="run_id_pgns")
 run_name = intersect(regex(r".*-[a-f0-9]{7}", name="run_name"), size(0, 23 + 1 + 7))
 action_message = intersect(str, size(0, 1024))


### PR DESCRIPTION
This seems to be equivalent to the regex in master but in principle it does not have to be.