### PR TITLE
Get port and primary_port from the config files development.ini and production.ini (RFC)

### DIFF
--- a/server/development.ini
+++ b/server/development.ini
@@ -17,6 +17,9 @@ debugtoolbar.hosts = 0.0.0.0/0 ::1
 
 mako.directories = fishtest:templates
 
+fishtest.port = 6542
+fishtest.primary_port = 6542
+
 ###
 # wsgi server configuration
 ###

--- a/server/fishtest/__init__.py
+++ b/server/fishtest/__init__.py
@@ -41,7 +41,13 @@ def main(global_config, **settings):
         for j in static_full_path(i).glob(f"*.{i}")
     }
 
-    rundb = RunDb()
+    port = int(settings.get("fishtest.port", -1))
+    primary_port = int(settings.get("fishtest.primary_port", -1))
+    # If the port number cannot be determined like during unit tests or CI,
+    # assume the instance is primary for backward compatibility.
+    is_primary_instance = port == primary_port
+
+    rundb = RunDb(port=port, is_primary_instance=is_primary_instance)
 
     def add_rundb(event):
         event.request.rundb = rundb

--- a/server/production.ini
+++ b/server/production.ini
@@ -14,6 +14,9 @@ pyramid.default_locale_name = en
 
 mako.directories = fishtest:templates
 
+fishtest.port = %(http_port)s
+fishtest.primary_port = 6543
+
 ###
 # wsgi server configuration
 ###


### PR DESCRIPTION
This gets rid of some ugly code in rundb.py.