### PR TITLE
Fully dynamic updates of run["cores"] and run["workers"] (RFC)

### DIFF
--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -1373,8 +1373,7 @@ def tests_delete(request):
 
         run["deleted"] = True
         run["finished"] = True
-        for task in run["tasks"]:
-            task["active"] = False
+        request.rundb.set_inactive_run(run)
         request.rundb.buffer(run, True)
         request.rundb.task_time = 0
 


### PR DESCRIPTION
We have everywhere replaced
```python
task["active"] = False
```
by
```python
set_inactive(task_id, run)
```
which does the required bookkeeping under the `task_lock`.

The intention is that the `task_lock` will only be held for a very short time. So in `request_task` we only grab it at the moment when we actually add a task to the run (currently it is held during the whole invocation of `request_task`).

If it works then this PR can serve as a model for other types of bookkeeping like the number of committed games.

Other change:
    
 We start the cache timer in `__init__.py` at application start up instead of during the first invocation of `buffer()`.
