### PR TITLE
two-sided resign adjudication

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -1508,6 +1508,7 @@ def run_games(worker_info, password, remote, run, task_id, pgn_file, clear_binar
                     "-resign",
                     "movecount=3",
                     "score=600",
+                    "twosided=true",
                     "-draw",
                     "movenumber=34",
                     "movecount=8",


### PR DESCRIPTION
enable two-sided adjudication, meaning both engines have to agree on the resignation for it to happen. i believe it is fairer this way.

to be more specific, i think of a scenario where one of the engine might have found a line that could lead to it losing, but the other engine might not find that line, by having twosided resignation, this prevents the more "pessimistic" stockfish from being wrongly adjudicated.