### PR TITLE
Make buffer() a noop on a non-primary instance.

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -353,6 +353,13 @@ class RunDb:
         self.timer.start()
 
     def buffer(self, run, flush):
+        if not self.is_primary_instance():
+            print(
+                "Warning: attempt to use the run_cache on the",
+                f"secondary instance with port number {self.port}!",
+                flush=True,
+            )
+            return
         with self.run_cache_lock:
             if self.timer is None:
                 self.start_timer()


### PR DESCRIPTION
So a non-primary instance will never accidentally write to the rundb.