### PR TITLE
Strip URLs before adding slashes

### DIFF
--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -772,7 +772,9 @@ def get_valid_books():
 
 def get_sha(branch, repo_url):
     """Resolves the git branch to sha commit"""
-    api_url = repo_url.replace("https://github.com", "https://api.github.com/repos")
+    api_url = repo_url.replace(
+        "https://github.com", "https://api.github.com/repos"
+    ).rstrip("/")
     try:
         commit = requests.get(api_url + "/commits/" + branch).json()
     except:
@@ -787,7 +789,7 @@ def get_nets(commit_sha, repo_url):
     """Get the nets from evaluate.h or ucioption.cpp in the repo"""
     api_url = repo_url.replace(
         "https://github.com", "https://raw.githubusercontent.com"
-    )
+    ).rstrip("/")
     try:
         nets = []
         pattern = re.compile("nn-[a-f0-9]{12}.nnue")
@@ -1176,7 +1178,7 @@ def new_run_message(request, run):
 
 def get_master_sha(repo_url):
     try:
-        repo_url += "/commits/master"
+        repo_url = repo_url.rstrip("/") + "/commits/master"
         response = requests.get(repo_url).json()
         if "commit" not in response:
             raise Exception("Cannot find branch in repository")

--- a/server/utils/clone_fish.py
+++ b/server/utils/clone_fish.py
@@ -29,7 +29,9 @@ def main():
     in_sync = False
     loaded = {}
     while True:
-        pgn_list = requests.get(fish_host + "/api/pgn_100/" + str(skip)).json()
+        pgn_list = requests.get(
+            fish_host.rstrip("/") + "/api/pgn_100/" + str(skip)
+        ).json()
         for pgn_file in pgn_list:
             print(pgn_file)
             if pgndb.find_one({"run_id": pgn_file}):
@@ -41,9 +43,11 @@ def main():
                 run_id = pgn_file.split("-")[0]
                 if not runs.find_one({"_id": run_id}):
                     print("New run: " + run_id)
-                    run = requests.get(fish_host + "/api/get_run/" + run_id).json()
+                    run = requests.get(
+                        fish_host.rstrip("/") + "/api/get_run/" + run_id
+                    ).json()
                     runs.insert(run)
-                pgn = requests.get(fish_host + "/api/pgn/" + pgn_file)
+                pgn = requests.get(fish_host.rstrip("/") + "/api/pgn/" + pgn_file)
                 pgndb.insert(
                     dict(pgn_bz2=Binary(bz2.compress(pgn.content)), run_id=pgn_file)
                 )

--- a/worker/games.py
+++ b/worker/games.py
@@ -325,7 +325,7 @@ def download_net(remote, testing_dir, net, global_cache):
     content = cache_read(global_cache, net)
 
     if content is None:
-        url = remote + "/api/nn/" + net
+        url = remote.rstrip("/") + "/api/nn/" + net
         print("Downloading {}".format(net))
         content = requests_get(url, allow_redirects=True, timeout=HTTP_TIMEOUT).content
         cache_write(global_cache, net, content)
@@ -725,7 +725,7 @@ def setup_engine(
         blob = cache_read(global_cache, sha + ".zip")
 
         if blob is None:
-            item_url = github_api(repo_url) + "/zipball/" + sha
+            item_url = github_api(repo_url).rstrip("/") + "/zipball/" + sha
             print("Downloading {}".format(item_url))
             blob = requests_get(item_url).content
             cache_write(global_cache, sha + ".zip", blob)
@@ -1081,7 +1081,7 @@ def parse_cutechess_output(
                 for _ in range(5):
                     try:
                         response = send_api_post_request(
-                            remote + "/api/update_task", result
+                            remote.rstrip("/") + "/api/update_task", result
                         )
                         if "error" in response:
                             break
@@ -1128,7 +1128,7 @@ def launch_cutechess(
 ):
     if spsa_tuning:
         # Request parameters for next game.
-        req = send_api_post_request(remote + "/api/request_spsa", result)
+        req = send_api_post_request(remote.rstrip("/") + "/api/request_spsa", result)
         if "error" in req:
             raise WorkerException(req["error"])
 

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 241, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "BMuQUpxZAKF0aP6ByTZY1r06MfPoIbdG2xraTrDQQRKgvhzJo6CKmeX2P8vX/QDm", "games.py": "9dFaa914vpqT7q4LLx2LlDdYwK6QFVX3h7+XRt18ATX0lt737rvFeBIiqakkttNC"}
+{"__version": 241, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "fe6qJsBfcRqGQB0epZvMzA3JLN/ze0Rd8ehAUv21ONAUJBgSKzoiWKbMBNqKuIpV", "games.py": "pqzRdXjCEwcSD4GezfZCrTodtAwargItAHOogtLO3WA82yLbfDY31XDNIpkzQFRA"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -347,7 +347,7 @@ def verify_credentials(remote, username, password, cached):
         payload = {"worker_info": {"username": username}, "password": password}
         try:
             req = send_api_post_request(
-                remote + "/api/request_version", payload, quiet=True
+                remote.rstrip("/") + "/api/request_version", payload, quiet=True
             )
         except:
             return None  # network problem (unrecoverable)
@@ -1220,7 +1220,9 @@ def heartbeat(worker_info, password, remote, current_state):
                 print("Skipping heartbeat ...")
                 continue
             try:
-                req = send_api_post_request(remote + "/api/beat", payload, quiet=True)
+                req = send_api_post_request(
+                    remote.rstrip("/") + "/api/beat", payload, quiet=True
+                )
             except Exception as e:
                 print("Exception calling heartbeat:\n", e, sep="", file=sys.stderr)
             else:
@@ -1248,7 +1250,9 @@ def verify_worker_version(remote, username, password):
     print("Verify worker version...")
     payload = {"worker_info": {"username": username}, "password": password}
     try:
-        req = send_api_post_request(remote + "/api/request_version", payload)
+        req = send_api_post_request(
+            remote.rstrip("/") + "/api/request_version", payload
+        )
     except WorkerException:
         return None  # the error message has already been written
     if "error" in req:
@@ -1314,7 +1318,7 @@ def fetch_and_handle_task(
     print("Fetching task...")
     payload = {"worker_info": worker_info, "password": password}
     try:
-        req = send_api_post_request(remote + "/api/request_task", payload)
+        req = send_api_post_request(remote.rstrip("/") + "/api/request_task", payload)
     except WorkerException:
         return False  # error message has already been printed
 
@@ -1356,7 +1360,7 @@ def fetch_and_handle_task(
     success = False
     message = ""
     server_message = ""
-    api = remote + "/api/failed_task"
+    api = remote.rstrip("/") + "/api/failed_task"
     pgn_file = [None]
     try:
         run_games(
@@ -1378,7 +1382,7 @@ def fetch_and_handle_task(
     except RunException as e:
         message = str(e)
         server_message = message
-        api = remote + "/api/stop_run"
+        api = remote.rstrip("/") + "/api/stop_run"
     except WorkerException as e:
         message = str(e)
         server_message = message
@@ -1426,7 +1430,9 @@ def fetch_and_handle_task(
                             len(payload["pgn"])
                         )
                     )
-                    req = send_api_post_request(remote + "/api/upload_pgn", payload)
+                    req = send_api_post_request(
+                        remote.rstrip("/") + "/api/upload_pgn", payload
+                    )
                 except Exception as e:
                     print(
                         "\nException uploading PGN file:\n", e, sep="", file=sys.stderr


### PR DESCRIPTION
this adds the practice of always stripping before adding slashes to the URLs.. one example is that the run page doesn't work with a repo with a slash at the end.