### PR TITLE
Danger alert for mismatching options

### DIFF
--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -249,6 +249,12 @@
         </div>
       </div>
 
+      % if 'spsa' not in run['args'] and run['args'].get('base_options', 'Hash=16').replace(" ", "") != run['args'].get('new_options', 'Hash=16').replace(" ", ""):
+          <div class="alert alert-danger mb-2">
+            Base engine options are not the same as the new engine options
+          </div>
+      % endif
+
       % if run.get('base_same_as_master') is not None:
         % if run['base_same_as_master']:
           <div id="master-diff" class="alert alert-success">


### PR DESCRIPTION
this gives a warning for mismatching options
a patch with hash=512 vs hash=64 has made its place in Stockfish master
the yellow highlight is for demonstration purposes (done with paint, I don't think we need any).
![Capture](https://github.com/official-stockfish/fishtest/assets/41402573/c78c879f-668d-497e-86ca-ac9a092f4a3d)