### PR TITLE
Do not evict a run from the cache which has active tasks.

### DIFF
--- a/server/fishtest/schemas.py
+++ b/server/fishtest/schemas.py
@@ -698,7 +698,7 @@ runs_schema = intersect(
 cache_schema = {
     run_id: {
         "run": runs_schema,
-        "is_changed": bool,  # Indicates if the run has changed since last write to db.
+        "is_changed": bool,  # Indicates if the run has changed since last_sync_time.
         "last_sync_time": ufloat,  # Last sync time (reading from or writing to db). If never synced then creation time.
         "last_access_time": ufloat,  # Last time the cache entry was touched (via buffer() or get_run()).
         "last_scavenge_time?": ufloat,  # Last time the run was scanned for dead tasks.


### PR DESCRIPTION
A dead task (a task which has not been updated for 360s) will only be scavenged if it belongs to a run in the cache. However clean runs are evicted from the cache after 300s. So if the run does not get new tasks, for example because it has low priority, the dead tasks remain unscavenged until somebody explicitly looks at the run (this pulls the run back in the cache).

Obviously it is not nice that dead tasks are not scavenged as soon as possible. Moreover the fact that the behavior of the server is affected by executing a GET request is a violation of the HTTP specs.
