### PR TITLE
Refactor minimum requirement version for compiler and add logic to clang

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -34,7 +34,7 @@ Proper configuration of `nginx` is crucial for this, and should be done
 according to the route/URL mapping defined in `__init__.py`.
 """
 
-WORKER_VERSION = 238
+WORKER_VERSION = 239
 
 
 @exception_view_config(HTTPException)

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 238, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "7FlRa167wPSzIddoZGLHZ4bf/F4wP8odD5V2QsfqU915VUydqkC3ujHsRVrB8c8L", "games.py": "6vKH51UtL56oNvA539hLXRzgE1ADXy3QZNJohoK94RntM72+iMancSJZHaNjEb5+"}
+{"__version": 239, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "+ubGHk3rIV0ILVhg1dxpsOkRF8GUaO5otPVnAyw8kKKq9Rqzksv02xj6wjYpSTmA", "games.py": "6vKH51UtL56oNvA539hLXRzgE1ADXy3QZNJohoK94RntM72+iMancSJZHaNjEb5+"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -55,7 +55,14 @@ from updater import update
 # Several packages are called "expression".
 # So we make sure to use the locally installed one.
 
-WORKER_VERSION = 238
+# Minimum requirement of compiler version for Stockfish.
+MIN_GCC_MAJOR = 7
+MIN_GCC_MINOR = 3
+
+MIN_CLANG_MAJOR = 8
+MIN_CLANG_MINOR = 0
+
+WORKER_VERSION = 239
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0
@@ -1048,10 +1055,10 @@ def gcc_version():
         print("Failed to parse g++ version.")
         return None
 
-    if (major, minor) < (7, 3):
+    if (major, minor) < (MIN_GCC_MAJOR, MIN_GCC_MINOR):
         print(
-            "Found g++ version {}.{}.{}. First usable version is 7.3.0.".format(
-                major, minor, patchlevel
+            "Found g++ version {}.{}.{}. First usable version is {}.{}.0".format(
+                major, minor, patchlevel, MIN_GCC_MAJOR, MIN_GCC_MINOR
             )
         )
         return None
@@ -1091,6 +1098,15 @@ def clang_version():
     except:
         print("Failed to parse clang++ version.")
         return None
+
+    if (major, minor) < (MIN_CLANG_MAJOR, MIN_CLANG_MINOR):
+        print(
+            "Found clang++ version {}.{}.{}. First usable version is {}.{}.0".format(
+                major, minor, patchlevel, MIN_CLANG_MAJOR, MIN_CLANG_MINOR
+            )
+        )
+        return None
+
     # Check for a common toolchain issue
     try:
         subprocess.run(


### PR DESCRIPTION
Same behaviour as before except that we now reject clang in case it is older than 8.0 (released 2019), 7.0 wasn't able to compile latest master for me. 