### PR TITLE
Bug fix for #2030

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -486,10 +486,11 @@ class RunDb:
                         if self.scavenge(run):
                             with self.run_cache_write_lock:
                                 self.runs.replace_one({"_id": run["_id"]}, run)
-                    if (
-                        run["cores"] <= 0
-                        and cache_entry["last_access_time"] < now - 300
-                    ):
+                    # Presently run["finished"] implies run["cores"]==0 but
+                    # this was not always true in the past.
+                    if (run["cores"] <= 0 or run["finished"]) and cache_entry[
+                        "last_access_time"
+                    ] < now - 300:
                         del self.run_cache[r_id]
                 elif cache_entry["last_sync_time"] < old:
                     old = cache_entry["last_sync_time"]


### PR DESCRIPTION
With the present code a finished run with `run["cores"]>0` will never be evicted from the cache. This is not a legal condition but it happened in the past because of race conditions.

This explains why #2030 seemed to create more unvalidated runs. The illegal runs become more and more likely to be selected for validation as they are not evicted and eventually dominate the cache.