### PR TITLE
Split `flush_buffers()`

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -517,13 +517,12 @@ class RunDb:
         with self.run_cache_lock:
             for cache_entry in self.run_cache.values():
                 run = cache_entry["run"]
-                if not cache_entry["is_changed"] and not run["finished"]:
+                if not run["finished"]:
                     for task_id, task in enumerate(run["tasks"]):
                         if (
                             task["active"]
                             and task["last_updated"].timestamp() < now - 360
                         ):
-                            cache_entry["is_changed"] = True
                             dead_tasks.append((task_id, run))
         # We release the lock to avoid deadlock
         for task_id, run in dead_tasks:
@@ -541,6 +540,7 @@ class RunDb:
                 task_id=task_id,
             )
             self.set_inactive_task(task_id, run)
+            self.buffer(run, False)
 
     def get_unfinished_runs_id(self):
         with self.run_cache_write_lock:


### PR DESCRIPTION
This is a PR on top of #2047 

Split the convoluted `flush_buffers()` into three scheduled tasks
 
- `flush_buffers()`: syncs oldest cache entry (period: 1s)
- `clean_cache()`: evicts old cache entries (period: 60s)
- `scavenge_dead_tasks()`: (period: 60s).
    
This PR should also fix the deadlock #2041.