### PR TITLE
Enhancement of validation.

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -17,7 +17,7 @@ from bson.objectid import ObjectId
 from fishtest.actiondb import ActionDb
 from fishtest.schemas import (
     RUN_VERSION,
-    cache_schema_fast,
+    cache_schema,
     compute_committed_games,
     compute_cores,
     compute_results,
@@ -277,7 +277,15 @@ class RunDb:
                 for task_id in range(len(run["tasks"])):
                     self.insert_in_wtt_map(run, task_id)
 
-        validate(cache_schema_fast, self.run_cache)
+        try:
+            validate(
+                cache_schema,
+                self.run_cache,
+                name="run_cache",
+                subs={"runs_schema": dict},
+            )
+        except ValidationError as e:
+            print(f"Validation of run_cache failed: {str(e)}")
 
     def new_run(
         self,

--- a/server/fishtest/schemas.py
+++ b/server/fishtest/schemas.py
@@ -32,6 +32,7 @@ from vtjson import (
     one_of,
     quote,
     regex,
+    set_label,
     set_name,
     size,
     union,
@@ -753,17 +754,11 @@ runs_schema = intersect(
     valid_aggregated_data,
 )
 
-# For documentation. Not fully used.
 cache_schema = {
     run_id: {
-        "run": runs_schema,
+        "run": set_label(runs_schema, "runs_schema"),
         "is_changed": bool,  # Indicates if the run has changed since last_sync_time.
         "last_sync_time": ufloat,  # Last sync time (reading from or writing to db). If never synced then creation time.
         "last_access_time": ufloat,  # Last time the cache entry was touched (via buffer() or get_run()).
     },
 }
-
-# A version that does not validate the embedded runs
-cache_schema_fast = {}
-cache_schema_fast[run_id] = copy.deepcopy(cache_schema[run_id])
-cache_schema_fast[run_id]["run"] = dict


### PR DESCRIPTION
Many data structure in Fishtest contain references to a run objects. Naively validating such data structures means that we are also validating the embedded run objects, which is wasteful as these are already validated elsewhere.

The latest version of vtjson makes it possible to change subschemas during validation.

In this PR we define the cache_schema as
```python
cache_schema = {
    run_id: {
        "run": set_label(runs_schema, "runs_schema"),
	"is_changed": bool,
        "last_sync_time": ufloat,
        "last_access_time": ufloat,
    },
}
```
and we perform validation via
```
validate(cache_schema, self.run_cache, name="run_cache", subs={"runs_schema": dict})
```
Requires upgrade of vtjson.