### PR TITLE
Update task_runs list via a scheduled task with period 1 min.

### DIFF
--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -1263,11 +1263,7 @@ def tests_modify(request):
         run["approver"] = ""
 
     before = del_tasks(run)
-    run["finished"] = False
-    run["deleted"] = False
-    run["failed"] = False
-    run["is_green"] = False
-    run["is_yellow"] = False
+    request.rundb.set_active_run(run)
     run["args"]["num_games"] = int(request.POST["num-games"])
     run["args"]["priority"] = int(request.POST["priority"])
     run["args"]["throughput"] = int(request.POST["throughput"])
@@ -1279,7 +1275,7 @@ def tests_modify(request):
     ):
         run["args"]["info"] = request.POST["info"].strip()
     request.rundb.buffer(run, True)
-    request.rundb.update_unfinished_runs_task.schedule_now()
+    request.rundb.update_itp_task.schedule_now()
 
     after = del_tasks(run)
     message = []
@@ -1322,7 +1318,6 @@ def tests_stop(request):
             request.session.flash("Unable to modify another users run!", "error")
             return home(request)
 
-        run["finished"] = True
         request.rundb.stop_run(request.POST["run-id"])
         request.actiondb.stop_run(
             username=request.authenticated_userid,
@@ -1407,7 +1402,7 @@ def tests_delete(request):
                     message=message,
                 )
         request.rundb.buffer(run, True)
-        request.rundb.update_unfinished_runs_task.schedule_now()
+        request.rundb.update_itp_task.schedule_now()
 
         request.actiondb.delete_run(
             username=request.authenticated_userid,

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -1279,7 +1279,7 @@ def tests_modify(request):
     ):
         run["args"]["info"] = request.POST["info"].strip()
     request.rundb.buffer(run, True)
-    request.rundb.task_time = 0
+    request.rundb.update_unfinished_runs_task.schedule_now()
 
     after = del_tasks(run)
     message = []
@@ -1407,7 +1407,7 @@ def tests_delete(request):
                     message=message,
                 )
         request.rundb.buffer(run, True)
-        request.rundb.task_time = 0
+        request.rundb.update_unfinished_runs_task.schedule_now()
 
         request.actiondb.delete_run(
             username=request.authenticated_userid,

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -151,8 +151,11 @@ class TestApi(unittest.TestCase):
             {"username": cls.username, "cpu_hours": 0}
         )
 
+        cls.rundb.schedule_tasks()
+
     @classmethod
     def tearDownClass(cls):
+        cls.rundb.scheduler.stop()
         cls.rundb.runs.delete_many({})
         cls.rundb.userdb.users.delete_many({"username": cls.username})
         cls.rundb.userdb.clear_cache()
@@ -535,9 +538,11 @@ class TestRunFinished(unittest.TestCase):
         cls.rundb.userdb.user_cache.insert_one(
             {"username": cls.username, "cpu_hours": 0}
         )
+        cls.rundb.schedule_tasks()
 
     @classmethod
     def tearDownClass(cls):
+        cls.rundb.scheduler.stop()
         cls.rundb.userdb.users.delete_many({"username": cls.username})
         cls.rundb.userdb.clear_cache()
         cls.rundb.userdb.user_cache.delete_many({"username": cls.username})


### PR DESCRIPTION
Now it is computed (and cached) at the beginning of request_task. This could possibly lead to variation in the duration of request_task.

Also: general cleanup of request_task.

Also: we now maintain a set of unfinished runs so that it is no longer necessary to access the data base to get this list.