### PR TITLE
Retire `self.update_itp_task.schedule_now()`.

### DIFF
--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -1275,7 +1275,6 @@ def tests_modify(request):
     ):
         run["args"]["info"] = request.POST["info"].strip()
     request.rundb.buffer(run, True)
-    request.rundb.update_itp_task.schedule_now()
 
     after = del_tasks(run)
     message = []
@@ -1402,7 +1401,6 @@ def tests_delete(request):
                     message=message,
                 )
         request.rundb.buffer(run, True)
-        request.rundb.update_itp_task.schedule_now()
 
         request.actiondb.delete_run(
             username=request.authenticated_userid,


### PR DESCRIPTION
`update_itp()` is a successor to code that also updated the list of unfinished runs but the latter is now managed dynamically.

Itp values move slowly on the Fishtest time scale and there is no need to micro-manage them.