### PR TITLE
Update comments; validate whole runs.

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -423,30 +423,31 @@ class RunDb:
             "total_games": 0,
         }
 
-        # administrative flags
+        # Administrative flags.
+        # If the following comments are incorrect then that's a bug!
 
-        # "finished"
-        # set in stop_run(), /api/stop_run, /tests/delete
-        # cleared in purge_run(), /tests/modify
+        # set in set_inactive_run()
+        # cleared in set_active_run()
         new_run["finished"] = False
 
         # "deleted"
         # set in /tests/delete
+        # cleared in set_active_run()
         new_run["deleted"] = False
 
         # "failed"
         # set in /api/stop_run
-        # cleared in /tests/modify
+        # cleared in set_active_run()
         new_run["failed"] = False
 
         # "is_green"
-        # set in stop_run()
-        # cleared in purge_run(), /tests/modify
+        # set in stop_run(), purge_run()
+        # cleared in purge_run(), set_active_run()
         new_run["is_green"] = False
 
         # "is_yellow"
-        # set in stop_run()
-        # cleared in purge_run(), /tests/modify
+        # set in stop_run(), purge_run()
+        # cleared in purge_run(), set_active_run()
         new_run["is_yellow"] = False
 
         if rescheduled_from:

--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -26,7 +26,6 @@ from fishtest.schemas import (
     nn_schema,
     pgns_schema,
     runs_schema,
-    valid_aggregated_data,
 )
 from fishtest.stats.stat_util import SPRT_elo
 from fishtest.userdb import UserDb
@@ -162,12 +161,9 @@ class RunDb:
             # Make sure that the run object does not change while we are
             # validating it
             with self.active_run_lock(run_id):
-                # We verify only the aggregated data since the other
-                # data is not synchronized and may be in a transient
-                # inconsistent state
-                validate(valid_aggregated_data, run, "run")
+                validate(runs_schema, run, "run")
                 print(
-                    f"Validate_random_run: validated aggregated data in cache run {run_id}...",
+                    f"Validate_random_run: validated cache run {run_id}...",
                     flush=True,
                 )
         except ValidationError as e:

--- a/server/fishtest/schemas.py
+++ b/server/fishtest/schemas.py
@@ -747,10 +747,18 @@ runs_schema = intersect(
     lax(ifthen({"approved": True}, {"approver": username}, {"approver": ""})),
     lax(ifthen({"is_green": True}, {"is_yellow": False})),
     lax(ifthen({"is_yellow": True}, {"is_green": False})),
-    lax(ifthen({"failed": True}, {"finished": True})),
-    lax(ifthen({"deleted": True}, {"finished": True})),
-    lax(ifthen({"finished": True}, {"workers": 0, "cores": 0})),
-    lax(ifthen({"finished": True}, {"tasks": [{"active": False}, ...]})),
+    lax(
+        ifthen(
+            {"finished": False},
+            {"is_green": False, "is_yellow": False, "failed": False, "deleted": False},
+        )
+    ),
+    lax(
+        ifthen(
+            {"finished": True},
+            {"workers": 0, "cores": 0, "tasks": [{"active": False}, ...]},
+        )
+    ),
     valid_aggregated_data,
 )
 


### PR DESCRIPTION
Update comments about administrative flags.
    
Also: update schemas to more rigorously reflect this.

Validate whole run in "validate_random_run".
    
There are some race conditions in Fishtest so this will trigger some (event) log messages. This will help us fix the race conditions.

