### PR TITLE
Introduce a worker global cache

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -34,7 +34,7 @@ Proper configuration of `nginx` is crucial for this, and should be done
 according to the route/URL mapping defined in `__init__.py`.
 """
 
-WORKER_VERSION = 239
+WORKER_VERSION = 240
 
 
 @exception_view_config(HTTPException)

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 239, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "+ubGHk3rIV0ILVhg1dxpsOkRF8GUaO5otPVnAyw8kKKq9Rqzksv02xj6wjYpSTmA", "games.py": "6vKH51UtL56oNvA539hLXRzgE1ADXy3QZNJohoK94RntM72+iMancSJZHaNjEb5+"}
+{"__version": 240, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "UfgMIw5Cx6YM7wplqw+zQ6fqQQnaaUmFDG+1AQ4pY5+dw7fnAvUjzbw4i8lmooUc", "games.py": "9dFaa914vpqT7q4LLx2LlDdYwK6QFVX3h7+XRt18ATX0lt737rvFeBIiqakkttNC"}


### PR DESCRIPTION
introduce a global_cache to reduce downloads from github and the net server if multiple workers having a shared filesystem are run by one user. This should allow a fleet to run without overloading github.

If the user specifies the path that corresponds to the global cache, the network and the source zipball are cached.  They are used if available, and only downloaded (and stored) if not.

Storing the data in the cache has been done in such a way that it becomes available atomically on most file systems.