### PR TITLE
Different stale detection to avoid >1 workers in directory.

### DIFF
--- a/worker/packages/openlock/__init__.py
+++ b/worker/packages/openlock/__init__.py
@@ -1,0 +1,1 @@
+from .openlock import FileLock, OpenLockException, Timeout

--- a/worker/packages/openlock/openlock.py
+++ b/worker/packages/openlock/openlock.py
@@ -1,0 +1,159 @@
+import atexit
+import logging
+import os
+import threading
+import time
+from pathlib import Path
+
+__version__ = "0.0.1"
+
+logger = logging.getLogger(__name__)
+
+
+class OpenLockException(Exception):
+    pass
+
+
+class Timeout(OpenLockException):
+    pass
+
+
+# These deal with stale lock file detection
+_touch_period_default = 2.0
+_stale_timeout_default = 3.0
+_stale_race_delay_default = 0.5
+
+# This deals with acquiring locks
+_retry_period_default = 0.3
+
+
+class FileLock:
+    def __init__(
+        self,
+        lock_file,
+        detect_stale=False,
+        timeout=None,
+        _retry_period=_retry_period_default,
+        _touch_period=_touch_period_default,
+        _stale_timeout=_stale_timeout_default,
+        _stale_race_delay=_stale_race_delay_default,
+    ):
+        self.__lock_file = Path(lock_file)
+        self.__timeout = timeout
+        self.__detect_stale = detect_stale
+        self.__lock = threading.Lock()
+        self.__acquired = False
+        self.__timer = None
+        self.__retry_period = _retry_period
+        self.__touch_period = _touch_period
+        self.__stale_timeout = _stale_timeout
+        self.__stale_race_delay = _stale_race_delay
+        logger.debug(f"{self} created")
+
+    def __touch(self):
+        self.__lock_file.touch()
+        self.__timer = threading.Timer(self.__touch_period, self.__touch)
+        self.__timer.daemon = True
+        self.__timer.start()
+        if not self.__acquired:
+            self.__timer.cancel()
+
+    def __is_stale(self):
+        try:
+            mtime = os.path.getmtime(self.__lock_file)
+        except FileNotFoundError:
+            return False
+        except OSError as e:
+            logger.error(
+                "Unable to get the modification time of the lock file "
+                f"{self.__lock_file}: {str(e)}"
+            )
+            return False
+        if mtime < time.time() - self.__stale_timeout:
+            return True
+        return False
+
+    def __remove_lock_file(self):
+        try:
+            os.remove(self.__lock_file)
+            logger.debug(f"Lock file '{self.__lock_file}' removed")
+        except OSError:
+            pass
+
+    def acquire(self, detect_stale=None, timeout=None):
+        with self.__lock:
+            if timeout is None:
+                timeout = self.__timeout
+            if detect_stale is None:
+                detect_stale = self.__detect_stale
+            wait_time = 0
+            while True:
+                if detect_stale:
+                    if self.__is_stale():
+                        logger.debug(f"Removing stale lock file '{self.__lock_file}'")
+                        self.__remove_lock_file()
+                        time.sleep(self.__stale_race_delay)
+                try:
+                    fd = os.open(
+                        self.__lock_file,
+                        mode=0o644,
+                        flags=os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                    )
+                    os.write(fd, str(os.getpid()).encode())
+                    os.close(fd)
+                    atexit.register(self.__remove_lock_file)
+                    logger.debug(f"{self} acquired")
+                    self.__acquired = True
+                    self.__touch()
+                    break
+                except FileExistsError:
+                    pass
+
+                if timeout is not None and wait_time >= timeout:
+                    logger.debug(f"Unable to acquire {self}")
+                    raise Timeout(f"Unable to acquire {self}") from None
+                else:
+                    wait_time += self.__retry_period
+                    time.sleep(self.__retry_period)
+
+    def release(self):
+        with self.__lock:
+            if not self.__acquired:
+                logger.debug(
+                    f"Ignoring attempt at releasing {self} which we do not own"
+                )
+                return
+            self.__acquired = False
+            if self.__timer is not None:
+                self.__timer.cancel()
+            self.__remove_lock_file()
+            atexit.unregister(self.__remove_lock_file)
+            logger.debug(f"{self} released")
+
+    def locked(self):
+        with self.__lock:
+            return self.__acquired
+
+    def getpid(self):
+        with self.__lock:
+            if self.__acquired:
+                return os.getpid()
+            if self.__is_stale():
+                return None
+            try:
+                with open(self.__lock_file) as f:
+                    return int(f.read())
+            except Exception:
+                return None
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.release()
+
+    def __str__(self):
+        return f"FileLock('{self.__lock_file}')"
+
+    __repr__ = __str__

--- a/worker/packages/openlock/test.py
+++ b/worker/packages/openlock/test.py
@@ -1,0 +1,28 @@
+import logging
+import signal
+import sys
+import time
+
+from openlock import FileLock, Timeout
+
+logging.basicConfig(format="%(asctime)s:%(levelname)s:%(name)s:%(process)s:%(message)s")
+logger = logging.getLogger("openlock")
+logger.setLevel(logging.DEBUG)
+
+if __name__ == "__main__":
+    try:
+        with FileLock("test.lock", detect_stale=True, timeout=0) as L:
+            logger.debug(f"{L} locked by PID={L.getpid()}")
+
+            assert L.locked()
+
+            def cleanup(signum, frame):
+                L.release()
+                sys.exit()
+
+            signal.signal(signal.SIGTERM, cleanup)
+            signal.signal(signal.SIGINT, cleanup)
+            logger.info("Sleeping 20 seconds")
+            time.sleep(20)
+    except Timeout:
+        pass

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 239, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "+ubGHk3rIV0ILVhg1dxpsOkRF8GUaO5otPVnAyw8kKKq9Rqzksv02xj6wjYpSTmA", "games.py": "6vKH51UtL56oNvA539hLXRzgE1ADXy3QZNJohoK94RntM72+iMancSJZHaNjEb5+"}
+{"__version": 239, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "Z4eGT/xKOipSU0JZOPag5cL1rnsnKZ5er/JADScqPSVkdWICl+smnL9saRdgi3kY", "games.py": "6vKH51UtL56oNvA539hLXRzgE1ADXy3QZNJohoK94RntM72+iMancSJZHaNjEb5+"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -49,11 +49,17 @@ from games import (
     str_signal,
     unzip,
 )
-from packages import expression
+from packages import expression, openlock
 from updater import update
 
+# Note: the comment below should be above the last
+# two imports but isort insists on putting it here.
+#
 # Several packages are called "expression".
 # So we make sure to use the locally installed one.
+
+
+LOCK_FILE = Path(__file__).resolve().parent / "worker.lock"
 
 # Minimum requirement of compiler version for Stockfish.
 MIN_GCC_MAJOR = 7
@@ -1211,99 +1217,6 @@ def heartbeat(worker_info, password, remote, current_state):
         print("Heartbeat stopped")
 
 
-def read_int(file):
-    try:
-        return int(file.read_text())
-    except:
-        return None
-
-
-def write_int(file, n):
-    try:
-        file.write_text("{}\n".format(n))
-        return True
-    except:
-        return False
-
-
-def create_lock_file(lock_file):
-    print("Creating lock file {}".format(lock_file))
-    atexit.register(delete_lock_file, lock_file)
-    return write_int(lock_file, os.getpid())
-
-
-def delete_lock_file(lock_file):
-    pid = read_int(lock_file)
-    if pid is None or pid == os.getpid():
-        print("Deleting lock file {}".format(lock_file))
-        try:
-            lock_file.unlink()
-        except Exception as e:
-            print("Exception deleting the lock file\n", e, sep="", file=sys.stderr)
-
-
-def pid_valid(pid, name):
-    with ExitStack() as stack:
-        if IS_WINDOWS:
-            cmdlet = (
-                "(Get-CimInstance Win32_Process "
-                "-Filter 'ProcessId = {}').CommandLine"
-            ).format(pid)
-            p = stack.enter_context(
-                subprocess.Popen(
-                    [
-                        "powershell",
-                        cmdlet,
-                    ],
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.DEVNULL,
-                    universal_newlines=True,
-                    bufsize=1,
-                    close_fds=not IS_WINDOWS,
-                )
-            )
-        else:
-            p = stack.enter_context(
-                subprocess.Popen(
-                    # for busybox these options are undocumented...
-                    ["ps", "-f", "-a"],
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.DEVNULL,
-                    universal_newlines=True,
-                    bufsize=1,
-                    close_fds=not IS_WINDOWS,
-                )
-            )
-        for line in iter(p.stdout.readline, ""):
-            if name in line and str(pid) in line:
-                return True
-    return False
-
-
-def locked_by_others(lock_file, require_valid=True):
-    # At the start of the worker we tolerate an
-    # invalid or non existing lock file since we
-    # intend to replace it with one of our own.
-    # Once we have started, we only accept a
-    # valid lock file containing our own PID.
-    pid = read_int(lock_file)
-    if pid is None:
-        if require_valid:
-            print(
-                "\n*** Worker (PID={}) stopped! ***\n"
-                "Unable to read the lock file:\n{}.".format(os.getpid(), lock_file)
-            )
-        return require_valid
-    if pid != os.getpid() and (require_valid or pid_valid(pid, "worker.py")):
-        print(
-            "\n*** Worker (PID={}) stopped! ***\n"
-            "Another worker (PID={}) is already running in this directory, "
-            "using the lock file:\n{}".format(os.getpid(), pid, lock_file)
-        )
-        return True
-    return False
-
-
 def utcoffset():
     dst = time.localtime().tm_isdst == 1 and time.daylight != 0
     utcoffset = -time.altzone if dst else -time.timezone
@@ -1344,19 +1257,11 @@ def verify_worker_version(remote, username, password):
     return True
 
 
-def fetch_and_handle_task(
-    worker_info, password, remote, lock_file, current_state, clear_binaries
-):
+def fetch_and_handle_task(worker_info, password, remote, current_state, clear_binaries):
     # This function should normally not raise exceptions.
     # Unusual conditions are handled by returning False.
     # If an immediate exit is necessary then one can set
     # current_state["alive"] to False.
-
-    # The following check can be triggered theoretically
-    # but probably not in practice.
-    if locked_by_others(lock_file):
-        current_state["alive"] = False
-        return False
 
     # Print the current time for log purposes
     print(
@@ -1517,32 +1422,19 @@ def fetch_and_handle_task(
 
 
 def worker():
-    if Path(__file__).name != "worker.py":
-        print("The script must be named 'worker.py'!")
-        return 1
-
     print(LOGO)
+    worker_lock = openlock.FileLock(LOCK_FILE)
+    try:
+        worker_lock.acquire(detect_stale=True, timeout=0)
+    except openlock.Timeout:
+        print(
+            f"\n*** Another worker (with PID={worker_lock.getpid()}) is already running in this "
+            "directory ***"
+        )
+        return 1
 
     worker_dir = Path(__file__).resolve().parent
     print("Worker started in {} ... (PID={})".format(worker_dir, os.getpid()))
-
-    # Python doesn't have a cross platform file locking api.
-    # So we check periodically for the existence
-    # of a lock file.
-    lock_file = worker_dir / "worker.lock"
-    if locked_by_others(lock_file, require_valid=False):
-        return 1
-    if not create_lock_file(lock_file):
-        print("Creating lock file failed")
-        return 1
-    # The start of the worker is racy so after a small
-    # delay we check that we still have a valid
-    # lock file containing our own PID.
-    # This will stop duplicate workers right here,
-    # except on extremely slow systems.
-    time.sleep(0.5)
-    if locked_by_others(lock_file):
-        return 1
 
     # We record some state that is shared by the three
     # parallel event handling mechanisms:
@@ -1672,7 +1564,6 @@ def worker():
             worker_info,
             options.password,
             remote,
-            lock_file,
             current_state,
             clear_binaries,
         )
@@ -1692,7 +1583,11 @@ def worker():
             delay = INITIAL_RETRY_TIME
 
     if fish_exit:
+        print("Removing fish.exit file")
         (worker_dir / "fish.exit").unlink()
+
+    print("Releasing the worker lock")
+    worker_lock.release()
 
     print("Waiting for the heartbeat thread to finish...")
     heartbeat_thread.join(THREAD_JOIN_TIMEOUT)


### PR DESCRIPTION
We touch the lock file every two seconds and check the age of the lock file when we start the worker. If the lock file is too old then we consider it as stale.

For the actual lock we open the lock file with the flags `O_EXCL|O_CREAT`. This is atomic and will fail if the lock file already exists.

The logic has been refactored and is contained in a separate package `packages.openlock`.

Not tested on Windows but it does not use any window specific apis.