### PR TITLE
Fix red color `pre` before approving

### DIFF
--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -288,7 +288,7 @@ def format_results(run_results, run):
 
         if los >= 0.95:
             state = "accepted"
-        else:
+        elif run["approved"]:
             state = "rejected"
 
     result["info"].append(


### PR DESCRIPTION
currently fixed games test_view results_pre shows a red color if the test isn't even approved, fix that since the state isn't really rejected.

e.g. https://dfts-0.pigazzini.it/tests/view/66818436b72c7bf0c0059a07