### PR TITLE
Make new_run return a string instead of an ObjectId.

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -565,10 +565,10 @@ class RunDb:
             raise Exception(message)
 
         # We cannot use self.buffer since new_run does not have an id yet.
-        run_id = self.runs.insert_one(new_run).inserted_id
+        run_id = str(self.runs.insert_one(new_run).inserted_id)
 
         with self.unfinished_runs_lock:
-            self.unfinished_runs.add(str(run_id))
+            self.unfinished_runs.add(run_id)
 
         return run_id
 


### PR DESCRIPTION
The convention throughout the code base is that `run_id` is a string.

Since a `run_id` and the corresponding ObjectId print in exactly the same way, violating this convention may lead to hard to understand bugs such as this one

https://tests.stockfishchess.org/actions?action=log_message&user=&text=internal

which was introduced in #1993.