### PR TITLE
return 404 if a non-sprt run_id is abused to be used in a live_elo link

### DIFF
--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -1443,7 +1443,7 @@ def get_page_title(run):
 @view_config(route_name="tests_live_elo", renderer="tests_live_elo.mak")
 def tests_live_elo(request):
     run = request.rundb.get_run(request.matchdict["id"])
-    if run is None:
+    if run is None or "sprt" not in run["args"]:
         raise HTTPNotFound()
     return {"run": run, "page_title": get_page_title(run)}
 


### PR DESCRIPTION
e.g. https://tests.stockfishchess.org/tests/live_elo/66833b9895b0d1e881e81489 https://tests.stockfishchess.org/tests/live_elo/6683a096c4f539faa03268e5