### PR TITLE
fix cutechess command

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -1562,7 +1562,9 @@ def run_games(
                 "-recover",
                 "-repeat",
                 "-games",
-                str(int(games_to_play)),
+                "2",
+                "rounds",
+                str(int(games_to_play) // 2),
                 "-tournament",
                 "gauntlet",
             ]

--- a/worker/games.py
+++ b/worker/games.py
@@ -1563,7 +1563,7 @@ def run_games(
                 "-repeat",
                 "-games",
                 "2",
-                "rounds",
+                "-rounds",
                 str(int(games_to_play) // 2),
                 "-tournament",
                 "gauntlet",

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 241, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "BMuQUpxZAKF0aP6ByTZY1r06MfPoIbdG2xraTrDQQRKgvhzJo6CKmeX2P8vX/QDm", "games.py": "9dFaa914vpqT7q4LLx2LlDdYwK6QFVX3h7+XRt18ATX0lt737rvFeBIiqakkttNC"}
+{"__version": 241, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "BMuQUpxZAKF0aP6ByTZY1r06MfPoIbdG2xraTrDQQRKgvhzJo6CKmeX2P8vX/QDm", "games.py": "OOYhNAOQQYsDcfJYDQmYP0L2xik2s1Gn8nIdsVP91+bAbWgNGZ0F66vtb+k0BGJR"}


### PR DESCRIPTION
cutechess command in games.py is incorrectly formatted causing a bug where the pgn have all games with the tag `["Round 1"]` . this is first spotted by @Disservin 

this change is also necessary for an eventual fast-chess migration as fast-chess relies on the correct format.