### PR TITLE
Increasing the maximum number of tests users can follow from 15 to 20

### DIFF
--- a/server/fishtest/static/js/notifications.js
+++ b/server/fishtest/static/js/notifications.js
@@ -160,7 +160,7 @@ function notifyElo(entryStart, entryFinished) {
   });
 }
 
-const designCapacity = 15;
+const designCapacity = 20;
 
 function getNotifications() {
   let notifications;


### PR DESCRIPTION
Increasing the maximum number of tests users can follow from 15 to 20.
So users can keep track of more tests simultaneously, allowing for a more comprehensive overview of ongoing tests.
Also, the previous limit of 15 was arbitrary, and increasing the limit poses no risks. This adjustment aligns with user needs for better monitoring and management of tests.

P.s: The new limit of 20 is also an arbitrary number, but it is better than before, and from my point of view is enough to satisfy users activity. But the limit can be increased further if needed.