### PR TITLE
Switch from cutechess-cli to fastchess

### DIFF
--- a/.github/workflows/worker_msys2.yaml
+++ b/.github/workflows/worker_msys2.yaml
@@ -6,6 +6,7 @@ jobs:
   test:
     runs-on: windows-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - { sys: mingw64, env: x86_64,       comp: gcc }

--- a/.github/workflows/worker_posix.yaml
+++ b/.github/workflows/worker_posix.yaml
@@ -6,6 +6,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-13]
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]

--- a/AUTHORS
+++ b/AUTHORS
@@ -14,6 +14,7 @@ Fanael Linithien (Fanael)
 Fauzi Akram Dabat (FauziAkram)
 FieryDragonLord
 Gabe (MrBrain295)
+Gahtan Nahdi (gahtan-syarif)
 Giacomo Lorenzetti (G-Lorenz)
 Gian-Carlo Pascutto (gcp)
 Henri Wiechers (hwiechers)

--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -34,7 +34,7 @@ Proper configuration of `nginx` is crucial for this, and should be done
 according to the route/URL mapping defined in `__init__.py`.
 """
 
-WORKER_VERSION = 243
+WORKER_VERSION = 244
 
 
 @exception_view_config(HTTPException)

--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -1158,23 +1158,6 @@ After fixing the issues you can unblock the worker at
                 if not have_binary:
                     continue
 
-            # To avoid time losses in the case of large concurrency and short TC,
-            # probably due to cutechess-cli as discussed in issue #822,
-            # assign linux workers to LTC or multi-threaded jobs
-            # and windows workers only to LTC jobs
-            if max_threads >= 29:
-                if "windows" in worker_info["uname"].lower():
-                    tc_too_short = get_tc_ratio(run["args"]["tc"], base="55+0.5") < 1.0
-                else:
-                    tc_too_short = (
-                        get_tc_ratio(
-                            run["args"]["tc"], run["args"]["threads"], "35+0.3"
-                        )
-                        < 1.0
-                    )
-                if tc_too_short:
-                    continue
-
             # Limit the number of cores.
             # Currently this is only done for spsa.
             if "spsa" in run["args"]:

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 243, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "0XzbFWIVnI8/XA6Lvu4ZsPdrP2pR6+5blf7insff0J2a0heeiagkQ6uv3q8S1SUO", "games.py": "9dFaa914vpqT7q4LLx2LlDdYwK6QFVX3h7+XRt18ATX0lt737rvFeBIiqakkttNC"}
+{"__version": 244, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "wLku9t2pbaOQVCVJ9bwOzurhWVliodFxdKgseqRetHW4xRn0Vdz6Htkp/lW18e9O", "games.py": "XgtjKOh/Ejfk4ke34NTnXaNTJQAi+cAg1aOcP2hVU6U1p8p/EACncSaWPR1ikI/d"}

--- a/worker/tests/test_worker.py
+++ b/worker/tests/test_worker.py
@@ -70,8 +70,12 @@ class workerTest(unittest.TestCase):
     def test_toolchain_verification(self):
         self.assertTrue(worker.verify_toolchain())
 
-    def test_setup_cutechess(self):
-        self.assertTrue(worker.setup_cutechess(Path.cwd()))
+    def test_setup_fastchess(self):
+        self.assertTrue(
+            worker.setup_fastchess(
+                Path.cwd(), list(worker.detect_compilers().keys())[0], 4, ""
+            )
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
fixes https://github.com/official-stockfish/fishtest/issues/2106

This PR switches from cutechess-cli to fast-chess.

cutechess-cli has been serving us well in the past years, however, some issues have accumulated, namely the difficulty of compiling cutechess-cli, the observed timeouts at high concurrency and short TC, and e.g. slowness when indexing larger books.  fast-chess https://github.com/Disservin/fast-chess has addressed these issues, and has now probably become mature enough to serve as the game manager for fishtest.

As an example of its ability to deal with short TC and high concurrency:
https://github.com/official-stockfish/fishtest/pull/2119#issuecomment-2571563064
with concurrency 48, and TC 1+0.01s, no timeouts are observed.

fast-chess is built from sources, with the zip download as well as the binary cached as needed.  There is fine-grained control over which version of fast-chess is used, so we can easily upgrade for new features.

In this PR, fast-chess was built in cutechess compatibility to facilitate integration, and to benefit from the existing fishtest checks. After validation the full switch to 'native' fast-chess output, with its pentanomial and wld output for every game pair, has significantly simplified the worker's book-keeping.