### PR TITLE
Faster worker stop on terminated task.

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -34,7 +34,7 @@ Proper configuration of `nginx` is crucial for this, and should be done
 according to the route/URL mapping defined in `__init__.py`.
 """
 
-WORKER_VERSION = 244
+WORKER_VERSION = 245
 
 
 @exception_view_config(HTTPException)
@@ -316,7 +316,7 @@ class WorkerApi(GenericApi):
         task = self.task()
         task["last_updated"] = datetime.now(timezone.utc)
         self.request.rundb.buffer(run, False)
-        return self.add_time({})
+        return self.add_time({"task_alive": task["active"]})
 
     @view_config(route_name="api_request_spsa")
     def request_spsa(self):

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -484,7 +484,7 @@ class TestApi(unittest.TestCase):
         request = self.correct_password_request({"run_id": run_id, "task_id": 0})
         response = WorkerApi(request).beat()
         response.pop("duration", None)
-        self.assertEqual(response, {})
+        self.assertEqual(response, {"task_alive": True})
 
 
 class TestRunFinished(unittest.TestCase):

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 244, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "wLku9t2pbaOQVCVJ9bwOzurhWVliodFxdKgseqRetHW4xRn0Vdz6Htkp/lW18e9O", "games.py": "XgtjKOh/Ejfk4ke34NTnXaNTJQAi+cAg1aOcP2hVU6U1p8p/EACncSaWPR1ikI/d"}
+{"__version": 245, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "QBEGtc1FFzYtSTj2xMB93I6kk+pDaq4zYNzBKb3Ef+lNqfrgvkxkBKx98bqBxbEC", "games.py": "ZfcZJQrMsfXGITXwX01GnFKONqAO2ODr8kXfhP2lp+IL/+fHZuF3LnLRQZlh/Znp"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -69,7 +69,7 @@ MIN_GCC_MINOR = 3
 MIN_CLANG_MAJOR = 8
 MIN_CLANG_MINOR = 0
 
-WORKER_VERSION = 244
+WORKER_VERSION = 245
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0
@@ -1234,6 +1234,10 @@ def heartbeat(worker_info, password, remote, current_state):
             else:
                 if "error" not in req:
                     print("(received)")
+                    task_alive = req.get("task_alive", True)
+                    if not task_alive:
+                        current_state["task_id"] = None
+                        current_state["run"] = None
     else:
         print("Heartbeat stopped")
 


### PR DESCRIPTION
Instead of always waiting for the next update_task, we allow the heart beat api to stop handling a task in the worker.