### PR TITLE
Fix benign schema error.

### DIFF
--- a/server/fishtest/schemas.py
+++ b/server/fishtest/schemas.py
@@ -828,7 +828,7 @@ unfinished_runs_schema = {
 }
 
 active_runs_schema = {
-    "purge_count?": suint,
+    "purge_count?": uint,
     run_id: {
         "time": timestamp,
         "lock": threading.RLock,


### PR DESCRIPTION
See

https://tests.stockfishchess.org/actions?max_actions=1&action=log_message&user=&text=&before=1725836603.523324&run_id=

Probably, in a future PR, we will delegate the purging of the "active_runs" data structure to a scheduled task so that there is no more need for the "purge_count" field.