### PR TITLE
No comments count fetching on PTs

### DIFF
--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -637,7 +637,7 @@
   async function toggleTasks() {
     const button = document.getElementById("tasks-button");
     const active = button.textContent.trim() === "Hide";
-    if (active){
+    if (active) {
       button.textContent = "Show";
     }
     else {
@@ -872,7 +872,7 @@
           dots = 3; // fall back to the three dot diff request as the diff will be rebased
       % endif
     % else:
-      % if run["args"]["new_tag"] == "master" and run["args"]["base_tag"] == pt_info["pt_branch"]:
+      % if is_pt:
           dots = 3; // fall back to the three dot in case of PTs since official is always rebased
       % endif
       const apiUrlBase = apiUrlNew;
@@ -907,7 +907,9 @@
           console.warn("Could not save diff in localStorage");
         }
       }
-      fetchComments(diffApiUrl, options);
+      % if not is_pt:
+        fetchComments(diffApiUrl, options);
+      % endif
     } catch (e) {
       console.error(e);
       text = e + "\n" + "Suggested Fix: Most probably API limit rate exceeded, please try to add a GitHub personal token in your profile or 'View on GitHub'.";

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -1612,6 +1612,10 @@ def tests_view(request):
     if show_task >= len(run["tasks"]) or show_task < -1:
         show_task = -1
 
+    is_pt = (
+        run["args"]["new_tag"] == "master"
+        and run["args"]["base_tag"] == request.rundb.pt_info["pt_branch"]
+    )
     same_user = is_same_user(request, run)
 
     return {
@@ -1628,7 +1632,7 @@ def tests_view(request):
         "follow": follow,
         "can_modify_run": can_modify_run(request, run),
         "same_user": same_user,
-        "pt_info": request.rundb.pt_info,
+        "is_pt": is_pt,
     }
 
 


### PR DESCRIPTION
when fetching comments using the GitHub API, all the comment in between the two commits of master and SF16 are considered, this number might not be actually be interesting info or representitve, and since we fetch it each time with a refresh since we expect the comments count to update at any time, but not for PTs., that leads to wasteful API rate-limit usage.

Example: https://tests.stockfishchess.org/tests/view/668d79ae5034141ae5999e45
