### PR TITLE
Introduce GitHub OAuth Authentication

### DIFF
--- a/server/fishtest/__init__.py
+++ b/server/fishtest/__init__.py
@@ -177,5 +177,9 @@ def main(global_config, **settings):
     config.add_route("api_actions", "/api/actions")
     config.add_route("api_calc_elo", "/api/calc_elo")
 
+    # GitHub OAuth Routes
+    config.add_route("github_oauth", "/github/oauth")
+    config.add_route("github_callback", "/github/callback")
+
     config.scan()
     return config.make_wsgi_app()

--- a/server/fishtest/schemas.py
+++ b/server/fishtest/schemas.py
@@ -87,18 +87,25 @@ pgns_schema = intersect(
     size_is_length,
 )
 
-user_schema = {
-    "_id?": ObjectId,
-    "username": username,
-    "password": str,
-    "registration_time": datetime_utc,
-    "pending": bool,
-    "blocked": bool,
-    "email": email,
-    "groups": [str, ...],
-    "tests_repo": union("", url),
-    "machine_limit": uint,
-}
+user_schema = intersect(
+    {
+        "_id?": ObjectId,
+        "username": username,
+        "password?": str,
+        "registration_time": datetime_utc,
+        "pending": bool,
+        "blocked": bool,
+        "email?": email,
+        "github_id?": str,
+        "linked_github_username?": str,
+        "github_access_token?": str,
+        "groups": [str, ...],
+        "tests_repo?": union("", url),
+        "machine_limit": uint,
+    },
+    at_least_one_of("email", "github_id"),
+    at_least_one_of("password", "github_access_token"),
+)
 
 
 worker_schema = {

--- a/server/fishtest/templates/login.mak
+++ b/server/fishtest/templates/login.mak
@@ -58,6 +58,16 @@
 
     <button type="submit" class="btn btn-primary w-100">Login</button>
   </form>
+
+  <div class="text-md-center my-4">
+    <p>Or</p>
+    <form action="${request.route_url('github_oauth')}" method="post">
+      <input type="hidden" name="action" value="login">
+      <button type="submit" class="btn btn-secondary w-100">
+        <i class="fa-brands fa-github"></i> Log in with GitHub
+      </button>
+    </form>
+  </div>
 </div>
 
 <script

--- a/server/fishtest/templates/signup.mak
+++ b/server/fishtest/templates/signup.mak
@@ -117,6 +117,15 @@
 
     <button type="submit" class="btn btn-primary w-100">Register</button>
   </form>
+  <div class="text-md-center my-4">
+    <p>Or</p>
+    <form action="${request.route_url('github_oauth')}" method="post">
+      <input type="hidden" name="action" value="signup">
+      <button type="submit" class="btn btn-secondary w-100">
+        <i class="fa-brands fa-github"></i> Sign up with GitHub
+      </button>
+    </form>
+  </div>
 </div>
 
 <script

--- a/server/fishtest/templates/user.mak
+++ b/server/fishtest/templates/user.mak
@@ -40,7 +40,7 @@
         <li class="list-group-item bg-transparent text-break">Registered: ${format_date(user['registration_time'] if 'registration_time' in user else 'Unknown')}</li>
         % if not profile:
           <li class="list-group-item bg-transparent text-break">Tests Repository: 
-            % if user['tests_repo']:
+            % if 'tests_repo' in user and user['tests_repo']:
               <a class="alert-link" href="${user['tests_repo']}">${extract_repo_from_link(user['tests_repo'])}</a>
             % else:
               <span>-</span>
@@ -54,6 +54,14 @@
         % endif
         <li class="list-group-item bg-transparent text-break">
           Groups: ${format_group(user['groups'])}
+        </li>
+        <li class="list-group-item bg-transparent text-break">
+        Linked GitHub user: 
+        % if 'linked_github_username' in user and user['linked_github_username']:
+          <a class="alert-link" href="https://github.com/${user["linked_github_username"]}">GitHub/${user["linked_github_username"]}</a>
+        % else:
+          <span>No accounts linked</span>
+        % endif
         </li>
         <li class="list-group-item bg-transparent text-break">Machine Limit: ${limit}</li>
         <li class="list-group-item bg-transparent text-break">CPU-Hours: ${hours}</li>
@@ -273,6 +281,14 @@
       % endif
     % endif
   </form>
+  % if profile and not 'linked_github_username' in user:
+    <form action="${request.route_url('github_oauth')}" method="post">
+      <input type="hidden" name="action" value="link">
+      <button type="submit" class="btn btn-secondary w-100">
+        <i class="fa-brands fa-github"></i> Link GitHub Account
+      </button>
+    </form>
+  % endif
 </div>
 
 <script


### PR DESCRIPTION
This implements the long waited GitHub Auth
### Allows 3 options:
1- Registering with GitHub
2- Linking your existing profile with GitHub
3- Logging in with GitHub

### Instructions
- **Hide Sensitive Variables:** Ensure `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` are hidden in the configuration file.

- **Generate GitHub OAuth Keys:**
  1. Go to [GitHub OAuth Application Settings](https://github.com/settings/applications/new).
  2. Create a new OAuth application with the following details:
     - **Application Name:** Fishtest
     - **Homepage URL:** https://tests.stockfishchess.org/
     - **Authorization Callback URL:** https://tests.stockfishchess.org/github/callback

- **Update Configuration:** Replace `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` placeholders with the generated keys from GitHub.

Note: this PR only concerns the Web part. I will make it happen for workers after most of the PRs gets resolved, in a final effort to get rid of the most serious issue in the framework which is the usage of plain text passwords.

<details>
  <summary><h3>Preview:</h3></summary>

  ![Capture2](https://github.com/user-attachments/assets/17ec6c04-34f5-4d87-8d27-38af45465042)

  ![Capture](https://github.com/user-attachments/assets/049a8b6f-002e-41c6-8f29-7c3577b5c973)

  ![Capture3](https://github.com/user-attachments/assets/25c95a17-bf9a-40f0-95a3-c15629443347)

  ![Capture4](https://github.com/user-attachments/assets/af20c65c-4b2c-47cb-af5c-49ebe87aa6f9)

  ![Capture5](https://github.com/user-attachments/assets/67170768-0590-4e5a-85a4-c79b9d1756e6)

  ![Capture6](https://github.com/user-attachments/assets/3df170fc-056b-44d1-b83e-3bcbfb01cea9)
</details>

Closes #2132