### PR TITLE
Update README and AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-# List of authors for fishtest, as of December 14, 2023
+# List of authors for fishtest, as of January 6, 2025
 
 Gary Linscott (glinscott)
 
@@ -8,7 +8,7 @@ Chess13234
 chuckstables
 David (dav1312)
 David Zar
-dubslow
+Dubslow
 Fabian Fichter (ianfab)
 Fanael Linithien (Fanael)
 Fauzi Akram Dabat (FauziAkram)
@@ -26,6 +26,7 @@ Joost VandeVondele (vondele)
 Julian Willemer (NightlyKing)
 Jörg Oster (joergoster)
 Kamyar Kaviani
+LightningThunder1
 Linmiao Xu (linrock)
 Lucas Braesch (lucasart)
 Malcolm Campbell (xoto10)
@@ -53,11 +54,13 @@ theo77186
 Tom Vijlbrief (tomtor)
 Unai Corzo (unaiic)
 Vince Negri (cuddlestmonkey)
+Viren
 Werner Fenchel (wfenchel)
 
 Thanks to:
-Ilari Pihlajisto - https://github.com/cutechess/cutechess, which drives all the games!
+Ilari Pihlajisto - https://github.com/cutechess/cutechess, which played over 8.5 billion games
+Max Allendorf - https://github.com/Disservin/fastchess, which drives all the games
 Tord Romstad - for Glaurung
-Dariusz Orzechowski - opening book idea (perft generation + position score filtering)
-Stefan Pohl - Unbalanced Human Openings books
+Dariusz Orzechowski - for the opening book idea (perft generation + position score filtering)
+Stefan Pohl - for the Unbalanced Human Openings books
 https://flag-sprites.com - for the great flag sprites

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ for testing the chess engine [Stockfish](https://github.com/official-stockfish/S
 Developers submit patches with new ideas and improvements, CPU contributors install a fishtest worker on their computers to play some chess games in the background to help the developers testing the patches.
 
 The fishtest worker:
-- Automatically connects to the server to download a chess opening book, the [cutechess-cli](https://github.com/cutechess/cutechess) chess game manager and the chess engine sources (both for the current Stockfish and for the patch with the new idea). The sources will be compiled according to the type of the worker platform.
-- Starts a batch of games using cutechess-cli.
+- Automatically connects to the server to download a chess opening book, the [fastchess](https://github.com/Disservin/fastchess) chess game manager sources and the chess engine sources (both for the current Stockfish and for the patch with the new idea). The sources will be compiled according to the type of the worker platform.
+- Starts a batch of games using fastchess.
 - Uploads the games results on the server.
 
 The fishtest server:


### PR DESCRIPTION
Update after the switch from cutechess to fastchess.

Authors data from `git shortlog -s | cut -c8-`
Moved Gary Linscott in first position.