### PR TITLE
Fix race condition.

### DIFF
--- a/server/fishtest/schemas.py
+++ b/server/fishtest/schemas.py
@@ -794,7 +794,12 @@ runs_schema = intersect(
     lax(
         ifthen(
             {"finished": False},
-            {"is_green": False, "is_yellow": False, "failed": False, "deleted": False},
+            {
+                "is_green": False,
+                "is_yellow": False,
+                "failed": False,
+                "deleted": False,
+            },
         )
     ),
     lax(


### PR DESCRIPTION
See
https://tests.stockfishchess.org/api/get_run/677a6ec46b38f4f9629fe598

This run is finished and yet it has nonzero nps and games_per_minute. This is possible if the scheduled task runs at the same time as the finishing of the run. In this PR we fix this and we enforce nps=0.0 and games_per_minute=0.0 in the schema.