### PR TITLE
Kill worker quickly with "killall python" while building fastchess.

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -34,7 +34,7 @@ Proper configuration of `nginx` is crucial for this, and should be done
 according to the route/URL mapping defined in `__init__.py`.
 """
 
-WORKER_VERSION = 247
+WORKER_VERSION = 248
 
 
 @exception_view_config(HTTPException)

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 247, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "fnKb7BjtNafSyeNEDD4R8km3YFzO0SvQHVdn252B3lDsV2wxLr3mG6SxqCVw8Sqg", "games.py": "8UyMjj/55AlxsO+2R1R92NasutgdHbLH6K9rxJfTD4cq02JTyOP93IoOZ1H7we9R"}
+{"__version": 248, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "YA9hNMDqbs27C/3z3aFfGtTdjDFw5Cg3hAsYJudGQs8iwUlXT8Te7pCbn82uLYAt", "games.py": "8UyMjj/55AlxsO+2R1R92NasutgdHbLH6K9rxJfTD4cq02JTyOP93IoOZ1H7we9R"}


### PR DESCRIPTION
We use the same mechanism which is used for compiling stockfish.