### PR TITLE
Make fish.exit quit the worker after the next update_task.

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -34,7 +34,7 @@ Proper configuration of `nginx` is crucial for this, and should be done
 according to the route/URL mapping defined in `__init__.py`.
 """
 
-WORKER_VERSION = 249
+WORKER_VERSION = 250
 
 
 @exception_view_config(HTTPException)

--- a/worker/games.py
+++ b/worker/games.py
@@ -1074,6 +1074,9 @@ def parse_fastchess_output(
                 else:
                     current_state["last_updated"] = datetime.now(timezone.utc)
 
+                if (Path(__file__).resolve().parent / "fish.exit").is_file():
+                    raise WorkerException("Task stopped by 'fish.exit'")
+
     else:
         raise WorkerException(
             "{} is past end time {}".format(datetime.now(timezone.utc), end_time)

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 249, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "bJWvV/8Evx6rg0WBbIO/L1EvLDHh9ZOHKa96Q0U/WZnArqwlPPbcY7PsT9xDRcIW", "games.py": "EGzjcZd308MK6JgUQH1aAJBHsxoLJ/9q+4vCKbKecbY9oZzLEOEygQmM4G2YKEFD"}
+{"__version": 250, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "rRWsXlFkv+whgfQS9IIJVEWnbquhlDa0DYRkkJ43/L7NTRR9pt2+sA2hqHH0x9M/", "games.py": "iYN33XDHqgfXnQheUtghu9GsuYhL0XU85/wUijSu87QtuwbyeAzJf2/Roqfatwgf"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -69,7 +69,7 @@ MIN_GCC_MINOR = 3
 MIN_CLANG_MAJOR = 8
 MIN_CLANG_MINOR = 0
 
-WORKER_VERSION = 249
+WORKER_VERSION = 250
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0
@@ -1611,11 +1611,6 @@ def worker():
     fish_exit = False
     clear_binaries = True
     while current_state["alive"]:
-        if (worker_dir / "fish.exit").is_file():
-            current_state["alive"] = False
-            print("Stopped by 'fish.exit' file")
-            fish_exit = True
-            break
         success = fetch_and_handle_task(
             worker_info,
             options.password,
@@ -1625,7 +1620,12 @@ def worker():
             options.global_cache,
             worker_lock,
         )
-        if not current_state["alive"]:  # the user may have pressed Ctrl-C...
+        if (worker_dir / "fish.exit").is_file():
+            current_state["alive"] = False
+            print("Stopped by 'fish.exit' file")
+            fish_exit = True
+            break
+        elif not current_state["alive"]:  # the user may have pressed Ctrl-C...
             break
         elif not success:
             if options.fleet:


### PR DESCRIPTION
In other words: do not wait for the whole task to finish.