### PR TITLE
Add priority field to cache.

### DIFF
--- a/server/fishtest/schemas.py
+++ b/server/fishtest/schemas.py
@@ -825,6 +825,7 @@ cache_schema = {
         "is_changed": bool,  # Indicates if the run has changed since last_sync_time.
         "last_sync_time": timestamp,  # Last sync time (reading from or writing to db). If never synced then creation time.
         "last_access_time": timestamp,  # Last time the cache entry was touched (via buffer() or get_run()).
+        "priority": int,  # Entries with higher priority are synced first.
     },
 }
 


### PR DESCRIPTION
If we create a new task then we buffer the run with priority 1. In that way it will be the first in line for saving to the db.

There are several reasons for this PR.

- `upload_pgn` is served from a secondary instance. So we want to write the corresponding task to the db as quickly as possible, otherwise the api will fail.

-  If the tasks on the test page are served from a secondary instance then there may be entries in the event log that refer to tasks that have not yet been written to disk, probably baffling the users. So we want to make this interval as short as possible.