### PR TITLE
Update fastchess

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -34,7 +34,7 @@ Proper configuration of `nginx` is crucial for this, and should be done
 according to the route/URL mapping defined in `__init__.py`.
 """
 
-WORKER_VERSION = 248
+WORKER_VERSION = 249
 
 
 @exception_view_config(HTTPException)

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 248, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "YA9hNMDqbs27C/3z3aFfGtTdjDFw5Cg3hAsYJudGQs8iwUlXT8Te7pCbn82uLYAt", "games.py": "EGzjcZd308MK6JgUQH1aAJBHsxoLJ/9q+4vCKbKecbY9oZzLEOEygQmM4G2YKEFD"}
+{"__version": 249, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "bJWvV/8Evx6rg0WBbIO/L1EvLDHh9ZOHKa96Q0U/WZnArqwlPPbcY7PsT9xDRcIW", "games.py": "EGzjcZd308MK6JgUQH1aAJBHsxoLJ/9q+4vCKbKecbY9oZzLEOEygQmM4G2YKEFD"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -69,7 +69,7 @@ MIN_GCC_MINOR = 3
 MIN_CLANG_MAJOR = 8
 MIN_CLANG_MINOR = 0
 
-WORKER_VERSION = 248
+WORKER_VERSION = 249
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0
@@ -454,7 +454,7 @@ def setup_fastchess(worker_dir, compiler, concurrency, global_cache):
     testing_dir = worker_dir / "testing"
     testing_dir.mkdir(exist_ok=True)
 
-    fastchess_sha = "37c6e12feaef484cd5eff1313d794532aa0bff14"
+    fastchess_sha = "d053a83d641ace390d9079bdab7f7b94f103727f"
     username = "Disservin"
 
     fastchess = "fastchess" + EXE_SUFFIX


### PR DESCRIPTION
use release alpha 1.2.0

Fixes an issue with the build (test) process on large core workers (>200)