### PR TITLE
Include compiler and env in engine name. Retire clear_binaries.

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -34,7 +34,7 @@ Proper configuration of `nginx` is crucial for this, and should be done
 according to the route/URL mapping defined in `__init__.py`.
 """
 
-WORKER_VERSION = 250
+WORKER_VERSION = 251
 
 
 @exception_view_config(HTTPException)

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 250, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "rRWsXlFkv+whgfQS9IIJVEWnbquhlDa0DYRkkJ43/L7NTRR9pt2+sA2hqHH0x9M/", "games.py": "iYN33XDHqgfXnQheUtghu9GsuYhL0XU85/wUijSu87QtuwbyeAzJf2/Roqfatwgf"}
+{"__version": 251, "updater.py": "Mg+pWOgGA0gSo2TuXuuLCWLzwGwH91rsW1W3ixg3jYauHQpRMtNdGnCfuD1GqOhV", "worker.py": "mfLxjM3Pq6448qSPwbLq5lTqX1nxMVBZbz8iv4Pkn9jPzhwHULsNCtFWw7ThcPAy", "games.py": "IZmJeczQV7IDMOvWS1NqR/tPe+Zg3rI8D1QDYIz/dvRE8auUU66PEjyfhWf9nbNe"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -69,7 +69,7 @@ MIN_GCC_MINOR = 3
 MIN_CLANG_MAJOR = 8
 MIN_CLANG_MINOR = 0
 
-WORKER_VERSION = 250
+WORKER_VERSION = 251
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0
@@ -1298,7 +1298,6 @@ def fetch_and_handle_task(
     password,
     remote,
     current_state,
-    clear_binaries,
     global_cache,
     worker_lock,
 ):
@@ -1391,7 +1390,6 @@ def fetch_and_handle_task(
             run,
             task_id,
             pgn_file,
-            clear_binaries,
             global_cache,
         )
         success = True
@@ -1609,14 +1607,12 @@ def worker():
     # Start the main loop.
     delay = INITIAL_RETRY_TIME
     fish_exit = False
-    clear_binaries = True
     while current_state["alive"]:
         success = fetch_and_handle_task(
             worker_info,
             options.password,
             remote,
             current_state,
-            clear_binaries,
             options.global_cache,
             worker_lock,
         )
@@ -1637,7 +1633,6 @@ def worker():
                 safe_sleep(delay)
                 delay = min(MAX_RETRY_TIME, delay * 2)
         else:
-            clear_binaries = False
             delay = INITIAL_RETRY_TIME
 
     if fish_exit:


### PR DESCRIPTION
Currently the worker deletes cached binaries on restart. The reason is that the user may have changed compilers, so that new engine binaries would be matched against old engine binaries, built with a different compiler.
    
In this PR we add compiler+version and a hash of selected environment variables to the engine name so that there is no risk of matching engine binaries built with different compilers, or with  different environment variables.
    
A possible enhancement (not in this PR) would be to also add the full build command to the engine name so that engine binaries could even be preserved across worker updates (a worker update may change the build command).
