### PR TITLE
Disable caching the main page.

### DIFF
--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -1729,15 +1729,6 @@ def homepage_results(request):
     }
 
 
-# For caching the homepage tests output
-cache_time = 2
-last_tests = None
-last_time = 0
-
-# Guard against parallel builds of main page
-building = threading.Semaphore()
-
-
 @view_config(route_name="tests", renderer="tests.mak")
 def tests(request):
     request.response.headerlist.extend(
@@ -1751,27 +1742,7 @@ def tests(request):
         # page 2 and beyond only show finished test results
         return get_paginated_finished_runs(request)
 
-    global last_tests, last_time
-    if time.time() - last_time > cache_time:
-        acquired = building.acquire(last_tests is None)
-        if not acquired:
-            # We have a current cache and another thread is rebuilding,
-            # so return the current cache
-            pass
-        elif time.time() - last_time < cache_time:
-            # Another thread has built the cache for us, so we are done
-            building.release()
-        else:
-            # Not cached, so calculate and fetch homepage results
-            try:
-                last_tests = homepage_results(request)
-            except Exception as e:
-                print("Overview exception: " + str(e))
-                if not last_tests:
-                    raise e
-            finally:
-                last_time = time.time()
-                building.release()
+    last_tests = homepage_results(request)
 
     return {
         **last_tests,


### PR DESCRIPTION
It is seems to be no longer necessary as the main page now builds very fast.

This will also solve the glitch than an approved test sometimes still shows on the main page as unapproved (because the main page came from the cache).