### PR TITLE
Save a run with finished tasks with higher priority.

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -297,7 +297,6 @@ class WorkerApi(GenericApi):
                 self.request.rundb.stop_run(self.run_id())
             else:
                 self.request.rundb.set_inactive_task(self.task_id(), run)
-                self.request.rundb.buffer(run, True)
 
         self.handle_error(error, exception=HTTPUnauthorized)
         return self.add_time({})


### PR DESCRIPTION
Sometimes the worker list on the main page shows a worker seemingly working on two different tasks - which is impossible. This illusion occurs when one of the tasks is a new one and the other task is a finished task by the same worker which has not been written to disk yet. So from the point of view of the db it is still unfinished.

This PR mitigates this issue by buffering a run with finished tasks with priority 1 (note: a run with new tasks is buffered with priority 2, other runs are buffered with priority 0).

Another reason for this PR is that we want to reduce the number of direct buffer calls. This PR moves some buffer calls deeper in the call chain.