### PR TITLE
Move some more buffer calls deeper in the call chain

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -314,7 +314,7 @@ class WorkerApi(GenericApi):
         run = self.run()
         task = self.task()
         task["last_updated"] = datetime.now(timezone.utc)
-        self.request.rundb.buffer(run, False)
+        self.request.rundb.buffer(run)
         return self.add_time({"task_alive": task["active"]})
 
     @view_config(route_name="api_request_spsa")

--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -291,6 +291,7 @@ class RunDb:
             run["games_per_minute"] = 0.0
             flags = compute_flags(run)
             run.update(flags)
+        self.buffer(run, True)
 
     def set_active_run(self, run):
         run_id = str(run["_id"])
@@ -301,6 +302,7 @@ class RunDb:
             run["is_green"] = False
             run["is_yellow"] = False
             run["finished"] = False
+        self.buffer(run, True)
 
     def set_inactive_task(self, task_id, run):
         run_id = run["_id"]
@@ -1581,8 +1583,6 @@ After fixing the issues you can unblock the worker at
                     flush=True,
                 )
 
-        self.buffer(run, True)
-
         # Auto-purge runs here. This may revive the run.
         if run["args"].get("auto_purge", True) and "spsa" not in run["args"]:
             message = self.purge_run(run)
@@ -1688,7 +1688,7 @@ After fixing the issues you can unblock the worker at
             else:
                 flags = compute_flags(run)
                 run.update(flags)
-            self.buffer(run, True)
+                self.buffer(run, True)
         return message
 
     def spsa_param_clip(self, param, increment):

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -4,6 +4,7 @@ import math
 import re
 import threading
 from datetime import datetime, timedelta, timezone
+from enum import IntEnum
 from functools import cache
 from random import uniform
 
@@ -14,6 +15,13 @@ from email_validator import EmailNotValidError, caching_resolver, validate_email
 from zxcvbn import zxcvbn
 
 FISH_URL = "https://tests.stockfishchess.org/tests/view/"
+
+
+class Prio(IntEnum):
+    NORMAL = 0
+    MEDIUM = 1
+    HIGH = 2
+    SAVE_NOW = 1000
 
 
 class GeneratorAsFileReader:

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -13,6 +13,7 @@ import fishtest.stats.stat_util
 import requests
 from fishtest.schemas import RUN_VERSION, runs_schema, short_worker_name
 from fishtest.util import (
+    Prio,
     email_valid,
     extract_repo_from_link,
     format_bounds,
@@ -1405,7 +1406,7 @@ def tests_delete(request):
                     username="fishtest.system",
                     message=message,
                 )
-        request.rundb.buffer(run, True)
+        request.rundb.buffer(run, priority=Prio.SAVE_NOW)
 
         request.actiondb.delete_run(
             username=request.authenticated_userid,

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -1267,7 +1267,6 @@ def tests_modify(request):
         run["approver"] = ""
 
     before = del_tasks(run)
-    request.rundb.set_active_run(run)
     run["args"]["num_games"] = int(request.POST["num-games"])
     run["args"]["priority"] = int(request.POST["priority"])
     run["args"]["throughput"] = int(request.POST["throughput"])
@@ -1278,7 +1277,7 @@ def tests_modify(request):
         and request.POST["info"].strip() != ""
     ):
         run["args"]["info"] = request.POST["info"].strip()
-    request.rundb.buffer(run, True)
+    request.rundb.set_active_run(run)
 
     after = del_tasks(run)
     message = []

--- a/server/tests/test_rundb.py
+++ b/server/tests/test_rundb.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 
 import util
 from fishtest.api import WORKER_VERSION
+from fishtest.util import Prio
 from pymongo import DESCENDING
 
 run_id = None
@@ -96,7 +97,7 @@ class CreateRunDBTest(unittest.TestCase):
         }
         run["tasks"].append(task)
 
-        self.rundb.buffer(run, True)
+        self.rundb.buffer(run, priority=Prio.SAVE_NOW)
 
         # LTC
         run_id = self.rundb.new_run(
@@ -152,7 +153,7 @@ class CreateRunDBTest(unittest.TestCase):
         run["tasks"][0]["active"] = True
         run["tasks"][0]["worker_info"] = self.worker_info
         run["workers"] = run["cores"] = 1
-        self.rundb.buffer(run, True)
+        self.rundb.buffer(run, priority=Prio.SAVE_NOW)
         self.rundb.connections_counter[self.remote_addr] = 1
         run = self.rundb.update_task(
             self.worker_info,
@@ -188,7 +189,7 @@ class CreateRunDBTest(unittest.TestCase):
         # revive task
         run_ = self.rundb.get_run(run_id)
         run_["tasks"][0]["active"] = True
-        self.rundb.buffer(run_, True)
+        self.rundb.buffer(run_, priority=Prio.SAVE_NOW)
         self.rundb.connections_counter[self.remote_addr] = 1
         run = self.rundb.update_task(
             self.worker_info,
@@ -223,7 +224,7 @@ class CreateRunDBTest(unittest.TestCase):
         print("run_id: {}".format(run_id))
         run = self.rundb.get_run(run_id)
         run["finished"] = True
-        self.rundb.buffer(run, True)
+        self.rundb.buffer(run, priority=Prio.SAVE_NOW)
 
     def test_40_list_LTC(self):
         finished_runs = self.rundb.get_finished_runs(limit=3, ltc_only=True)[0]
@@ -238,7 +239,7 @@ class CreateRunDBTest(unittest.TestCase):
                 run["finished"] = True
                 for w in run["tasks"]:
                     w["pending"] = False
-                self.rundb.buffer(run, True)
+                self.rundb.buffer(run, priority=Prio.SAVE_NOW)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In the second commit in this PR we convert the `priority` argument to `buffer` to use an `Enum` and we retire the positional `flush` argument in favor of `priority=Prio.SAVE_NOW`.
