### PR TITLE
Synchronize flush_all().

### DIFF
--- a/server/fishtest/__init__.py
+++ b/server/fishtest/__init__.py
@@ -98,9 +98,12 @@ def main(global_config, **settings):
         # We do not want to do the following in the constructor of rundb since
         # it writes to the db and starts the flush timer.
         if rundb.is_primary_instance():
+            rundb.update_aggregated_data()
+            # We install signal handlers when all cache sensitive code in the
+            # main thread is finished. In that way we can safely use
+            # locks in the signal handlers (which also run in the main thread).
             signal.signal(signal.SIGINT, rundb.exit_run)
             signal.signal(signal.SIGTERM, rundb.exit_run)
-            rundb.update_aggregated_data()
             rundb.schedule_tasks()
 
     config.add_subscriber(add_rundb, NewRequest)

--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -681,7 +681,7 @@ class RunDb:
         if self.scheduler is not None:
             print("Stopping scheduler... ", flush=True)
             self.scheduler.stop()
-        if self.__is_primary_instance:
+        if self.is_primary_instance():
             print("Flushing cache... ", flush=True)
             self.run_cache.flush_all()
         if self.port >= 0:

--- a/server/fishtest/scheduler.py
+++ b/server/fishtest/scheduler.py
@@ -182,10 +182,16 @@ class Scheduler:
         self._refresh()
         return task
 
+    def join(self):
+        """Join worker thread - if possible"""
+        if threading.current_thread() != self.__worker_thread:
+            self.__worker_thread.join()
+
     def stop(self):
         """This stops the scheduler"""
         self.__thread_stopped = True
         self._refresh()
+        self.join()
 
     def _refresh(self):
         self.__event.set()


### PR DESCRIPTION
The former comment about deadlock seems outdated to me. Signal handlers run in the main thread and Fishtest executes no code in the main thread once initialization is finished. So signal handlers behave like asynchronous events in the same way as api calls do, and the latter appear currently to be deadlock free.

In a second commit we make a small tweak in the procedure to stop the scheduler.