### PR TITLE
fix: close test mongodb connection on exit

### DIFF
--- a/server/tests/util.py
+++ b/server/tests/util.py
@@ -1,12 +1,17 @@
+import atexit
+
 from fishtest.rundb import RunDb
 
 
 def get_rundb():
-    return RunDb(db_name="fishtest_tests")
+    rundb = RunDb(db_name="fishtest_tests")
+    atexit.register(rundb.conn.close)
+    return rundb
 
 
 def find_run(arg="username", value="travis"):
     rundb = RunDb(db_name="fishtest_tests")
+    atexit.register(rundb.conn.close)
     for run in rundb.get_unfinished_runs():
         if run["args"][arg] == value:
             return run


### PR DESCRIPTION
Fix the warnings in server tests.

```python
/opt/hostedtoolcache/Python/3.13.1/x64/lib/python3.13/unittest/suite.py:84: ResourceWarning: Unclosed MongoClient opened at:
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code

...
  File "/home/runner/work/fishtest/fishtest/server/fishtest/rundb.py", line 61, in __init__
    self.conn = MongoClient(os.getenv("FISHTEST_HOST") or "localhost")
Call MongoClient.close() to safely shut down your client and free up resources.
  return self.run(*args, **kwds)
```