### PR TITLE
refactor(worker): improve import from "packages"

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -34,7 +34,7 @@ Proper configuration of `nginx` is crucial for this, and should be done
 according to the route/URL mapping defined in `__init__.py`.
 """
 
-WORKER_VERSION = 259
+WORKER_VERSION = 260
 
 
 @exception_view_config(HTTPException)

--- a/worker/games.py
+++ b/worker/games.py
@@ -23,7 +23,10 @@ from pathlib import Path
 from queue import Empty, Queue
 from zipfile import ZipFile
 
-import requests
+try:
+    import requests
+except ImportError:
+    from packages import requests
 
 IS_WINDOWS = "windows" in platform.system().lower()
 IS_MACOS = "darwin" in platform.system().lower()

--- a/worker/packages/__init__.py
+++ b/worker/packages/__init__.py
@@ -1,0 +1,28 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+
+class LazyModule(types.ModuleType):
+    def __init__(self, name):
+        super().__init__(name)
+        self._module_path = f".{name}"
+        self._module = None
+
+    def _load(self):
+        if self._module is None:
+            pkg_path = str(Path(__file__).resolve().parent)
+            if pkg_path not in sys.path:
+                sys.path.append(pkg_path)
+            self._module = importlib.import_module(self._module_path, __name__)
+        return self._module
+
+    def __getattr__(self, item):
+        module = self._load()
+        return getattr(module, item)
+
+
+requests = LazyModule("requests")
+
+__all__ = ["requests"]

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 259, "updater.py": "hr1R/uj8Vk8dTC7VsGwL8IaQurgaDvtXE3adDzv0dSoUExQYmrherGto9ozMIz8o", "worker.py": "b7qXrA8mrjgro54PajvQnCO50/CWyedOAvtvc8ZwEcF06S6tLC8AScVIaAEhm6nn", "games.py": "RfSvmPmdIEiyLj6iwYMBcxmOgq0OlqE3pcik07PQb8zPIJPMG9ED+xliBm9ameSP"}
+{"__version": 260, "updater.py": "dpMIHELIfaXCmCM4Bpge2G7Oikl1AiQq5tvQIQeS7WJcMSzVdVX/XvtRf5xFYRSQ", "worker.py": "rGnE235WQNOooh3eafGIAdzJpRONYef5mbmGHRnZM0r5odLqctRSYVKG0ZL4n4Yq", "games.py": "Tud76gpfJLNKUgg/nA4XIXJqutVKWo7fZUDZ4gsdONBH89Vh90BYlo2lmuTDZGEY"}

--- a/worker/updater.py
+++ b/worker/updater.py
@@ -6,7 +6,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from zipfile import ZipFile
 
-import requests
+try:
+    import requests
+except ImportError:
+    from packages import requests
+
 from games import EXE_SUFFIX
 
 start_dir = Path().cwd()

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -25,12 +25,19 @@ from datetime import datetime, timedelta, timezone
 from functools import partial
 from pathlib import Path
 
-# Fall back to the provided packages if missing in the local system.
+try:
+    from expression import Expression_Parser
+except ImportError:
+    from packages.expression import Expression_Parser
+try:
+    import openlock
+except (ImportError, SyntaxError):
+    from packages import openlock
+try:
+    import requests
+except ImportError:
+    from packages import requests
 
-packages_dir = Path(__file__).resolve().parent / "packages"
-sys.path.append(str(packages_dir))
-
-import requests
 from games import (
     EXE_SUFFIX,
     IS_MACOS,
@@ -50,15 +57,7 @@ from games import (
     str_signal,
     unzip,
 )
-from packages import expression, openlock
 from updater import update
-
-# Note: the comment below should be above the last
-# two imports but isort insists on putting it here.
-#
-# Several packages are called "expression".
-# So we make sure to use the locally installed one.
-
 
 LOCK_FILE = Path(__file__).resolve().parent / "fishtest_worker.lock"
 
@@ -71,20 +70,19 @@ MIN_CLANG_MINOR = 0
 
 FASTCHESS_SHA = "894616028492ae6114835195f14a899f6fa237d3"
 
-WORKER_VERSION = 259
+WORKER_VERSION = 260
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0
 THREAD_JOIN_TIMEOUT = 15.0
 MAX_RETRY_TIME = 900.0  # 15 minutes
-IS_COLAB = False
 try:
     import google.colab
-
+except ImportError:
+    IS_COLAB = False
+else:
     IS_COLAB = True
     del google.colab
-except ImportError:
-    pass
 CONFIGFILE = "fishtest.cfg"
 
 LOGO = r"""
@@ -176,7 +174,7 @@ class _memory:
         self.__name__ = "memory"
 
     def __call__(self, x):
-        e = expression.Expression_Parser(
+        e = Expression_Parser(
             variables={"MAX": self.MAX}, functions={"min": min, "max": max}
         )
         try:
@@ -194,7 +192,7 @@ class _concurrency:
         self.__name__ = "concurrency"
 
     def __call__(self, x):
-        e = expression.Expression_Parser(
+        e = Expression_Parser(
             variables={"MAX": self.MAX}, functions={"min": min, "max": max}
         )
         try:


### PR DESCRIPTION
- Update `__init__.py` to lazily load submodules using a lightweight wrapper.
- When a module (e.g. "requests") is not available from the current
  environment, the fallback in the "packages" folder is used.
- Adjust `sys.path` only when "requests" is loaded from the fallback location,
  ensuring that the package path is appended only when necessary.
- The lazy loading mechanism is compatible with Python 3.6

Raise worker version to 260 (also server side)
