### PR TITLE
Refine handling of last_updated in stopped run

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -296,6 +296,7 @@ class RunDb:
                     + stats["losses"]
                     + stats["draws"]
                 )
+                task["last_updated"] = datetime.now(timezone.utc)
                 task["active"] = False
                 with self.connections_lock:
                     try:


### PR DESCRIPTION
This run https://tests.stockfishchess.org/tests/view/67b119e76c6b9e172ad15939?show_task=2 was stopped by the second task. However the other tasks have a more recent `last_updated` field, which is disturbing.

This PR probably fixes this by:

- in `set_inactive_task` we set the `last_updated` field to now;
- in `api_beat`, we only update `last_updated` if the task is active.