### PR TITLE
Do not revive a failed run.

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -568,7 +568,9 @@ class RunDb:
 
         # "failed"
         # set in /api/stop_run
-        # cleared in set_active_run()
+        # in principle cleared in set_active_run() to comply with the schema
+        # but this method should never be invoked on a failed run (if it is then
+        # it is a bug)
         new_run["failed"] = False
 
         # "is_green"

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -821,6 +821,16 @@ def parse_spsa_params(raw, spsa):
 
 
 def validate_modify(request, run):
+    now = datetime.now(timezone.utc)
+    if "start_time" not in run or (now - run["start_time"]).days > 30:
+        request.session.flash("Run too old to be modified", "error")
+        raise home(request)
+
+    # Do not revive failed runs
+    if run["failed"]:
+        request.session.flash("You cannot modify a failed run", "error")
+        raise home(request)
+
     if "num-games" not in request.POST:
         request.session.flash("Unable to modify with no number of games!", "error")
         raise home(request)
@@ -859,11 +869,6 @@ def validate_modify(request, run):
     max_games = 3200000
     if num_games > max_games:
         request.session.flash("Number of games must be <= " + str(max_games), "error")
-        raise home(request)
-
-    now = datetime.now(timezone.utc)
-    if "start_time" not in run or (now - run["start_time"]).days > 30:
-        request.session.flash("Run too old to be modified", "error")
         raise home(request)
 
 


### PR DESCRIPTION
This failed run was revived
https://tests.stockfishchess.org/actions?run_id=67b2f36338b351d1ce6405e1 and then predictably it failed again after some time. With this PR we disallow reviving a failed run.