### PR TITLE
Overhaul cachebuster logic

### DIFF
--- a/server/fishtest/__init__.py
+++ b/server/fishtest/__init__.py
@@ -1,5 +1,3 @@
-import base64
-import hashlib
 import signal
 import sys
 import threading
@@ -7,6 +5,7 @@ import traceback
 from pathlib import Path
 
 from fishtest import helpers
+from fishtest.routes import setup_routes
 from fishtest.rundb import RunDb
 from pyramid.authentication import AuthTktAuthenticationPolicy
 from pyramid.authorization import ACLAuthorizationPolicy
@@ -42,22 +41,6 @@ def main(global_config, **settings):
     config.include("pyramid_mako")
     config.set_default_csrf_options(require_csrf=False)
 
-    def static_full_path(static_path):
-        return Path(__file__).parent / f"static/{static_path}"
-
-    def file_hash(file):
-        return base64.b64encode(hashlib.sha384(file.read_bytes()).digest()).decode(
-            "utf8"
-        )
-
-    # hash calculated by browser for sub-resource integrity checks:
-    # https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
-    cache_busters = {
-        f"{i}/{j.name}": file_hash(j)
-        for i in ("css", "js")
-        for j in static_full_path(i).glob(f"*.{i}")
-    }
-
     port = int(settings.get("fishtest.port", -1))
     primary_port = int(settings.get("fishtest.primary_port", -1))
     # If the port number cannot be determined like during unit tests or CI,
@@ -74,7 +57,6 @@ def main(global_config, **settings):
 
     def add_renderer_globals(event):
         event["h"] = helpers
-        event["cache_busters"] = cache_busters
 
     def check_blocked_user(event):
         request = event.request
@@ -122,62 +104,7 @@ def main(global_config, **settings):
     )
     config.set_authorization_policy(ACLAuthorizationPolicy())
 
-    config.add_static_view("css", "static/css", cache_max_age=3600)
-    config.add_static_view("js", "static/js", cache_max_age=3600)
-    config.add_static_view("img", "static/img", cache_max_age=3600)
-    config.add_static_view("html", "static/html", cache_max_age=3600)
-
-    config.add_route("home", "/")
-    config.add_route("login", "/login")
-    config.add_route("nn_upload", "/upload")
-    config.add_route("logout", "/logout")
-    config.add_route("signup", "/signup")
-    config.add_route("user", "/user/{username}")
-    config.add_route("profile", "/user")
-    config.add_route("user_management", "/user_management")
-    config.add_route("contributors", "/contributors")
-    config.add_route("contributors_monthly", "/contributors/monthly")
-    config.add_route("actions", "/actions")
-    config.add_route("nns", "/nns")
-    config.add_route("sprt_calc", "/sprt_calc")
-    config.add_route("workers", "/workers/{worker_name}")
-
-    config.add_route("tests", "/tests")
-    config.add_route("tests_machines", "/tests/machines")
-    config.add_route("tests_finished", "/tests/finished")
-    config.add_route("tests_run", "/tests/run")
-    config.add_route("tests_view", "/tests/view/{id}")
-    config.add_route("tests_tasks", "/tests/tasks/{id}")
-    config.add_route("tests_user", "/tests/user/{username}")
-    config.add_route("tests_stats", "/tests/stats/{id}")
-    config.add_route("tests_live_elo", "/tests/live_elo/{id}")
-
-    # Tests - actions
-    config.add_route("tests_modify", "/tests/modify")
-    config.add_route("tests_delete", "/tests/delete")
-    config.add_route("tests_stop", "/tests/stop")
-    config.add_route("tests_approve", "/tests/approve")
-    config.add_route("tests_purge", "/tests/purge")
-
-    # API
-    config.add_route("api_request_task", "/api/request_task")
-    config.add_route("api_update_task", "/api/update_task")
-    config.add_route("api_failed_task", "/api/failed_task")
-    config.add_route("api_stop_run", "/api/stop_run")
-    config.add_route("api_request_version", "/api/request_version")
-    config.add_route("api_beat", "/api/beat")
-    config.add_route("api_request_spsa", "/api/request_spsa")
-    config.add_route("api_active_runs", "/api/active_runs")
-    config.add_route("api_finished_runs", "/api/finished_runs")
-    config.add_route("api_get_run", "/api/get_run/{id}")
-    config.add_route("api_get_task", "/api/get_task/{id}/{task_id}")
-    config.add_route("api_upload_pgn", "/api/upload_pgn")
-    config.add_route("api_download_pgn", "/api/pgn/{id}")
-    config.add_route("api_download_run_pgns", "/api/run_pgns/{id}")
-    config.add_route("api_download_nn", "/api/nn/{id}")
-    config.add_route("api_get_elo", "/api/get_elo/{id}")
-    config.add_route("api_actions", "/api/actions")
-    config.add_route("api_calc_elo", "/api/calc_elo")
+    setup_routes(config)
 
     config.scan()
     return config.make_wsgi_app()

--- a/server/fishtest/routes.py
+++ b/server/fishtest/routes.py
@@ -1,0 +1,90 @@
+import base64
+import hashlib
+
+from pyramid.path import AssetResolver
+from pyramid.static import QueryStringCacheBuster
+
+
+def setup_routes(config):
+    config.add_static_view("static", "static", cache_max_age=3600)
+
+    config.add_cache_buster(
+        "static/", FileHashCacheBuster(package="fishtest", base_path="static/")
+    )
+
+    config.add_route("home", "/")
+    config.add_route("login", "/login")
+    config.add_route("nn_upload", "/upload")
+    config.add_route("logout", "/logout")
+    config.add_route("signup", "/signup")
+    config.add_route("user", "/user/{username}")
+    config.add_route("profile", "/user")
+    config.add_route("user_management", "/user_management")
+    config.add_route("contributors", "/contributors")
+    config.add_route("contributors_monthly", "/contributors/monthly")
+    config.add_route("actions", "/actions")
+    config.add_route("nns", "/nns")
+    config.add_route("sprt_calc", "/sprt_calc")
+    config.add_route("workers", "/workers/{worker_name}")
+
+    config.add_route("tests", "/tests")
+    config.add_route("tests_machines", "/tests/machines")
+    config.add_route("tests_finished", "/tests/finished")
+    config.add_route("tests_run", "/tests/run")
+    config.add_route("tests_view", "/tests/view/{id}")
+    config.add_route("tests_tasks", "/tests/tasks/{id}")
+    config.add_route("tests_user", "/tests/user/{username}")
+    config.add_route("tests_stats", "/tests/stats/{id}")
+    config.add_route("tests_live_elo", "/tests/live_elo/{id}")
+
+    # Tests - actions
+    config.add_route("tests_modify", "/tests/modify")
+    config.add_route("tests_delete", "/tests/delete")
+    config.add_route("tests_stop", "/tests/stop")
+    config.add_route("tests_approve", "/tests/approve")
+    config.add_route("tests_purge", "/tests/purge")
+
+    # API
+    config.add_route("api_request_task", "/api/request_task")
+    config.add_route("api_update_task", "/api/update_task")
+    config.add_route("api_failed_task", "/api/failed_task")
+    config.add_route("api_stop_run", "/api/stop_run")
+    config.add_route("api_request_version", "/api/request_version")
+    config.add_route("api_beat", "/api/beat")
+    config.add_route("api_request_spsa", "/api/request_spsa")
+    config.add_route("api_active_runs", "/api/active_runs")
+    config.add_route("api_finished_runs", "/api/finished_runs")
+    config.add_route("api_get_run", "/api/get_run/{id}")
+    config.add_route("api_get_task", "/api/get_task/{id}/{task_id}")
+    config.add_route("api_upload_pgn", "/api/upload_pgn")
+    config.add_route("api_download_pgn", "/api/pgn/{id}")
+    config.add_route("api_download_run_pgns", "/api/run_pgns/{id}")
+    config.add_route("api_download_nn", "/api/nn/{id}")
+    config.add_route("api_get_elo", "/api/get_elo/{id}")
+    config.add_route("api_actions", "/api/actions")
+    config.add_route("api_calc_elo", "/api/calc_elo")
+
+
+class FileHashCacheBuster(QueryStringCacheBuster):
+    def __init__(self, package, base_path, param="x") -> None:
+        super().__init__(param)
+        self.asset_resolver = AssetResolver(package)
+        self.base_path = base_path
+        self.token_cache = {}
+
+    def tokenize(self, request, pathspec, kw):
+        cached = self.token_cache.get(pathspec)
+        if cached:
+            return cached
+
+        token = self._hash_asset(self._resolve_asset(pathspec))
+        self.token_cache[pathspec] = token
+
+        return token
+
+    def _resolve_asset(self, pathspec):
+        return self.asset_resolver.resolve(self.base_path + pathspec)
+
+    def _hash_asset(self, asset):
+        content = asset.stream().read()
+        return base64.b64encode(hashlib.sha384(content).digest()).decode("utf8")

--- a/server/fishtest/templates/base.mak
+++ b/server/fishtest/templates/base.mak
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <script>
-      const darkThemeHash = "${cache_busters['css/theme.dark.css']}";
+      const darkThemeHash = "${request.static_url('fishtest:static/css/theme.dark.css')}";
     </script>
 
     <link
@@ -35,17 +35,13 @@
 
     <link
       rel="stylesheet"
-      href="/css/application.css?v=${cache_busters['css/application.css']}"
-      integrity="sha384-${cache_busters['css/application.css']}"
-      crossorigin="anonymous"
+      href="${request.static_url('fishtest:static/css/application.css')}"
     >
 
     % if request.cookies.get('theme') == 'dark':
     <link
       rel="stylesheet"
-      href="/css/theme.dark.css?v=${cache_busters['css/theme.dark.css']}"
-      integrity="sha384-${cache_busters['css/theme.dark.css']}"
-      crossorigin="anonymous"
+      href="${request.static_url('fishtest:static/css/theme.dark.css')}"
     >
     % endif
 
@@ -57,17 +53,9 @@
       referrerpolicy="no-referrer"
     ></script>
 
-    <script
-      src="/js/application.js?v=${cache_busters['js/application.js']}"
-      integrity="sha384-${cache_busters['js/application.js']}"
-      crossorigin="anonymous"
-    ></script>
+    <script src="${request.static_url('fishtest:static/js/application.js')}"></script>
 
-    <script
-      src="/js/notifications.js?v=${cache_busters['js/notifications.js']}"
-      integrity="sha384-${cache_busters['js/notifications.js']}"
-      crossorigin="anonymous"
-    ></script>
+    <script src="${request.static_url('fishtest:static/js/notifications.js')}"></script>
 
     <%block name="head"/>
   </head>

--- a/server/fishtest/templates/login.mak
+++ b/server/fishtest/templates/login.mak
@@ -60,8 +60,4 @@
   </form>
 </div>
 
-<script
-  src="/js/toggle_password.js?v=${cache_busters['js/toggle_password.js']}"
-  integrity="sha384-${cache_busters['js/toggle_password.js']}"
-  crossorigin="anonymous"
-></script>
+<script src="${request.static_url('fishtest:static/js/toggle_password.js')}"></script>

--- a/server/fishtest/templates/signup.mak
+++ b/server/fishtest/templates/signup.mak
@@ -119,8 +119,4 @@
   </form>
 </div>
 
-<script
-  src="/js/toggle_password.js?v=${cache_busters['js/toggle_password.js']}"
-  integrity="sha384-${cache_busters['js/toggle_password.js']}"
-  crossorigin="anonymous"
-></script>
+<script src="${request.static_url('fishtest:static/js/toggle_password.js')}"></script>

--- a/server/fishtest/templates/sprt_calc.mak
+++ b/server/fishtest/templates/sprt_calc.mak
@@ -137,14 +137,6 @@
 
 <script src="https://www.gstatic.com/charts/loader.js"></script>
 
-<script
-  src="/js/sprt.js?v=${cache_busters['js/sprt.js']}"
-  integrity="sha384-${cache_busters['js/sprt.js']}"
-  crossorigin="anonymous"
-></script>
+<script src="${request.static_url('fishtest:static/js/sprt.js')}"></script>
 
-<script
-  src="/js/calc.js?1&v=${cache_busters['js/calc.js']}"
-  integrity="sha384-${cache_busters['js/calc.js']}"
-  crossorigin="anonymous"
-></script>
+<script src="${request.static_url('fishtest:static/js/calc.js')}"></script>

--- a/server/fishtest/templates/tests.mak
+++ b/server/fishtest/templates/tests.mak
@@ -2,9 +2,7 @@
 
 <link
   rel="stylesheet"
-  href="/css/flags.css?v=${cache_busters['css/flags.css']}"
-  integrity="sha384-${cache_busters['css/flags.css']}"
-  crossorigin="anonymous"
+  href="${request.static_url('fishtest:static/css/flags.css')}}"
 >
 
 <h2>Stockfish Testing Queue</h2>

--- a/server/fishtest/templates/tests_live_elo.mak
+++ b/server/fishtest/templates/tests_live_elo.mak
@@ -2,10 +2,7 @@
 
 <script src="https://www.gstatic.com/charts/loader.js"></script>
 
-<script src="/js/live_elo.js?v=${cache_busters['js/live_elo.js']}"
-        integrity="sha384-${cache_busters['js/live_elo.js']}"
-        crossorigin="anonymous"
-></script>
+<script src="${request.static_url('fishtest:static/js/live_elo.js')}"></script>
 
 <script>
   document.title = "Live Elo - ${page_title} | Stockfish Testing";

--- a/server/fishtest/templates/tests_run.mak
+++ b/server/fishtest/templates/tests_run.mak
@@ -982,11 +982,7 @@
   });
 </script>
 
-<script
-  src="/js/spsa_new.js?5&?v=${cache_busters['js/spsa_new.js']}"
-  integrity="sha384-${cache_busters['js/spsa_new.js']}"
-  crossorigin="anonymous"
-></script>
+<script src="${request.static_url('fishtest:static/js/spsa_new.js')}"></script>
 
 <script>
   function spsaWork() {

--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -49,11 +49,7 @@
     const spsaData = ${json.dumps(run["args"]["spsa"])|n};
   </script>
 
-  <script
-    src="/js/spsa.js?v=${cache_busters['js/spsa.js']}"
-    integrity="sha384-${cache_busters['js/spsa.js']}"
-    crossorigin="anonymous"
-  ></script>
+  <script src="${request.static_url('fishtest:static/js/spsa.js')}"></script>
 
   <script>
     const spsaPromise = handleSPSA();

--- a/server/fishtest/templates/user.mak
+++ b/server/fishtest/templates/user.mak
@@ -39,14 +39,14 @@
       <ul class="list-group list-group-flush">
         <li class="list-group-item bg-transparent text-break">Registered: ${format_date(user['registration_time'] if 'registration_time' in user else 'Unknown')}</li>
         % if not profile:
-          <li class="list-group-item bg-transparent text-break">Tests Repository: 
+          <li class="list-group-item bg-transparent text-break">Tests Repository:
             % if user['tests_repo']:
               <a class="alert-link" href="${user['tests_repo']}">${extract_repo_from_link(user['tests_repo'])}</a>
             % else:
               <span>-</span>
             % endif
           </li>
-          <li class="list-group-item bg-transparent text-break">Email: 
+          <li class="list-group-item bg-transparent text-break">Email:
             <a href="mailto:${user['email']}?Subject=Fishtest%20Account" class="alert-link">
               ${user['email']}
             </a>
@@ -180,22 +180,22 @@
           <div class="modal-content">
             <div class="modal-body">
               <!-- Explanation about token purpose -->
-              <p>The purpose of this token is to authenticate your requests to GitHub's API, 
-              which has a rate limit of 60 requests per hour for unauthenticated users. By using this token, 
-              you can increase this limit to 5000 requests per hour. More information about GitHub's rate limits can be found 
+              <p>The purpose of this token is to authenticate your requests to GitHub's API,
+              which has a rate limit of 60 requests per hour for unauthenticated users. By using this token,
+              you can increase this limit to 5000 requests per hour. More information about GitHub's rate limits can be found
               <a href="https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting" target="_blank">here</a>.
               </p>
-              
+
               <!-- Information about storage -->
               <p>This token will be stored in your local storage, not in the server database.
               This ensures that the token is only accessible to you, reducing the risk of unauthorized access.
               </p>
-              
+
               <!-- Permissions and access information -->
-              <p>The token should be granted the minimum permissions necessary for your use case. 
+              <p>The token should be granted the minimum permissions necessary for your use case.
               This reduces the potential impact if the token is accidentally exposed or misused.
               </p>
-              
+
               <!-- Instructions on how to obtain the token -->
               <h4>Instructions:</h4>
               <ol>
@@ -275,8 +275,4 @@
   </form>
 </div>
 
-<script
-  src="/js/toggle_password.js?v=${cache_busters['js/toggle_password.js']}"
-  integrity="sha384-${cache_busters['js/toggle_password.js']}"
-  crossorigin="anonymous"
-></script>
+<script src="${request.static_url('fishtest:static/js/toggle_password.js')}"></script>


### PR DESCRIPTION
Use the pyramid builtin way to write a cache buster by extending QueryStringCacheBuster.
While at it move the routes to a separate file for easier access.

The four individual 
```
config.add_static_view("css", "static/css", cache_max_age=3600)
config.add_static_view("js", "static/js", cache_max_age=3600)
config.add_static_view("img", "static/img", cache_max_age=3600)
config.add_static_view("html", "static/html", cache_max_age=3600)
```

were combined to just

```
config.add_static_view("static", "static", cache_max_age=3600)
```

I don't think this makes a big difference?