### PR TITLE
Add a print statement before benchmarking

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -1459,6 +1459,7 @@ def run_games(
         pass
 
     # Verify that the signatures are correct.
+    print("Benchmarking worker and verifying signature", flush=True)
     run_errors = []
     try:
         base_nps, cpu_features = verify_signature(

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 263, "updater.py": "dpMIHELIfaXCmCM4Bpge2G7Oikl1AiQq5tvQIQeS7WJcMSzVdVX/XvtRf5xFYRSQ", "worker.py": "Nr1nfd3ImO2BS+WjZut0k0vAag9nG1FWokkLThST8YJkWaIcvFQ9XXPEvdJQqkhY", "games.py": "Y9yBvj0YFdk314MVzR58FxCLVLve9fs6MO01w6g+8QFCW0xVlXPREdPAVvQlUYl1"}
+{"__version": 263, "updater.py": "dpMIHELIfaXCmCM4Bpge2G7Oikl1AiQq5tvQIQeS7WJcMSzVdVX/XvtRf5xFYRSQ", "worker.py": "Nr1nfd3ImO2BS+WjZut0k0vAag9nG1FWokkLThST8YJkWaIcvFQ9XXPEvdJQqkhY", "games.py": "3sc8PoGUA1j9BXH9of92LaKU3+zBlQqhOcEfPGbYmSSwBFCQgJGuGogg0JoYbgD9"}


### PR DESCRIPTION
As benchmarking takes some time, give some info to the user before this starts.