### PR TITLE
Make sure to buffer the run after request_spsa.

### DIFF
--- a/server/fishtest/run_cache.py
+++ b/server/fishtest/run_cache.py
@@ -67,7 +67,7 @@ class RunCache:
         Guidelines for priority
         =======================
         Prio.MEDIUM: finished task
-        Prio.HIGH: new task
+        Prio.HIGH: new task, request spsa
         Prio.SAVE_NOW: new run (combined with create=True),
                        finished run, modify/approve/purge run
         Prio.NORMAL: all other uses


### PR DESCRIPTION
If we don't do this then the spsa_params for the workers may not survive a server restart.

This fixes another issue with #2239.