### PR TITLE
Make the new spsa code robust against a server crash

### DIFF
--- a/server/fishtest/run_cache.py
+++ b/server/fishtest/run_cache.py
@@ -67,7 +67,7 @@ class RunCache:
         Guidelines for priority
         =======================
         Prio.MEDIUM: finished task
-        Prio.HIGH: new task, request spsa
+        Prio.HIGH: new task
         Prio.SAVE_NOW: new run (combined with create=True),
                        finished run, modify/approve/purge run
         Prio.NORMAL: all other uses

--- a/server/fishtest/schemas.py
+++ b/server/fishtest/schemas.py
@@ -634,7 +634,7 @@ valid_aggregated_data = intersect(
 # about non-validation of runs created with the prior
 # schema.
 
-RUN_VERSION = 8
+RUN_VERSION = 9
 
 runs_schema = intersect(
     {
@@ -758,14 +758,17 @@ runs_schema = intersect(
                     "start": uint,
                     "bad?": True,
                     "stats": results_schema,
-                    "spsa_params?": [
-                        {
-                            "R": unumber,
-                            "c": unumber,
-                            "flip": union(-1, 1),
-                        },
-                        ...,
-                    ],
+                    "spsa_params?": {
+                        "start": uint,
+                        "w_params": [
+                            {
+                                "R": unumber,
+                                "c": unumber,
+                                "flip": union(-1, 1),
+                            },
+                            ...,
+                        ],
+                    },
                     "worker_info": worker_info_schema_runs,
                 },
                 ifthen(

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -591,3 +591,7 @@ def strip_run(run):
         stripped[key] = str(run[key])
 
     return stripped
+
+
+def count_games(d):
+    return d["wins"] + d["losses"] + d["draws"]


### PR DESCRIPTION
In a task we store not only the spsa data but also the number of games in the task when the spsa data was generated.