### PR TITLE
Reduce the amount of statistics printed on worker start.

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -405,20 +405,11 @@ def compute_bench_statistics(results, threads, depth, *, bench_nps=False):
     median_nps = statistics.median(bench_nps_values)
     std_nps = statistics.stdev(bench_nps_values) if len(bench_nps_values) > 1 else 0
 
-    print(
-        f"Bench for {'nps' if bench_nps else 'nodes'}\n"
-        f"{'Concurrency':<15}: {len(results):15.2f}\n"
-        f"{'Threads':<15}: {threads:15.2f}\n"
-        f"{'Depth':<15}: {depth:15.2f}\n"
-        f"{'Mean nodes':<15}: {mean_nodes:15.2f}\n"
-        f"{'Mean time (ms)':<15}: {mean_time:15.2f}\n"
-        f"{'Mean nps':<15}: {mean_nps:15.2f}\n"
-        f"{'Median nps':<15}: {median_nps:15.2f}\n"
-        f"{'Min nps':<15}: {min_nps:15.2f}\n"
-        f"{'Max nps':<15}: {max_nps:15.2f}\n"
-        f"{'Std nps':<15}: {std_nps:15.2f}\n"
-        f"{'Std (%)':<15}: {100 * std_nps / mean_nps:15.2f}"
-    )
+    if bench_nps:
+        print(
+            f"{'Mean nps':<15}: {mean_nps:15.2f}\n"
+            f"{'Std (%)':<15}: {100 * std_nps / mean_nps:15.2f}"
+        )
 
     return mean_nps if bench_nps else None
 
@@ -1478,6 +1469,8 @@ def run_games(
 
     # Verify that the signatures are correct.
     print("Benchmarking worker and verifying signature...", flush=True)
+    print(f"{'Concurrency':<15}: {games_concurrency:15d}", flush=True)
+    print(f"{'Threads':<15}: {threads:15d}", flush=True)
     run_errors = []
     try:
         base_nps, cpu_features = verify_signature(

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 266, "updater.py": "PLWj7cnPP4rG8g5R5bJV0Za4kZpuRxbpcpebyFByXeFDUtfat/gfBn/0kJBMOY/m", "worker.py": "TJqQ23AKtNzyhQPFCbP5PgVkfWxsXIKgeRMZyjJoucki1gvopufiTyVu7/pjChSN", "games.py": "pk1Uz+WXN9RifXLX2R32ihAk78aAkRjar1GTSoNyZZ6OjtrdzKdhXdlpPxyTZU2D"}
+{"__version": 266, "updater.py": "PLWj7cnPP4rG8g5R5bJV0Za4kZpuRxbpcpebyFByXeFDUtfat/gfBn/0kJBMOY/m", "worker.py": "TJqQ23AKtNzyhQPFCbP5PgVkfWxsXIKgeRMZyjJoucki1gvopufiTyVu7/pjChSN", "games.py": "u5vYuAGNlEdrVqEt7rd5FUqF4l0qsYvxpf1todIuRV5glLkpy8qBvIBRqshck0hA"}


### PR DESCRIPTION
Perhaps this is controversial... This is how it looks

```
Benchmarking worker and verifying signature...
Concurrency    :               4
Threads        :               1
Statistics for stockfish_93b966829bd7d2d9d9dce49f11e20125f48d0cfd_g++_13.3:
Mean nps       :       583686.87
Std (%)        :            1.13
Statistics for stockfish_f551f1b5a204b728c3c3842192db51e1c1032be1_g++_13.3:
Mean nps       :       561182.67
Std (%)        :            2.00
```