### PR TITLE
Do not wrap byte arrays with Binary.

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -11,7 +11,6 @@ from datetime import UTC, datetime
 
 import fishtest.run_cache
 import fishtest.stats.stat_util
-from bson.binary import Binary
 from bson.codec_options import CodecOptions
 from bson.objectid import ObjectId
 from fishtest.actiondb import ActionDb
@@ -607,7 +606,7 @@ class RunDb:
         return self.__is_primary_instance
 
     def upload_pgn(self, run_id, pgn_zip):
-        record = {"run_id": run_id, "pgn_zip": Binary(pgn_zip), "size": len(pgn_zip)}
+        record = {"run_id": run_id, "pgn_zip": pgn_zip, "size": len(pgn_zip)}
         try:
             validate(pgns_schema, record)
         except ValidationError as e:
@@ -1560,9 +1559,10 @@ After fixing the issues you can unblock the worker at
         task["spsa_params"] = {}
         task["spsa_params"]["start"] = count_games(task["stats"])
         task["spsa_params"]["iter"] = spsa["iter"]
-        task["spsa_params"]["packed_flips"] = Binary(
-            pack_flips([w_param["flip"] for w_param in result["w_params"]])
+        task["spsa_params"]["packed_flips"] = pack_flips(
+            [w_param["flip"] for w_param in result["w_params"]]
         )
+
         self.buffer(run)
         return result
 

--- a/server/fishtest/schemas.py
+++ b/server/fishtest/schemas.py
@@ -10,7 +10,6 @@ import threading
 from datetime import UTC, datetime
 
 import fishtest.stats.stat_util
-from bson.binary import Binary
 from bson.objectid import ObjectId
 from vtjson import (
     anything,
@@ -82,7 +81,7 @@ pgns_schema = intersect(
     {
         "_id?": ObjectId,
         "run_id": run_id_pgns,
-        "pgn_zip": intersect(Binary, gzip_data),
+        "pgn_zip": intersect(bytes, gzip_data),
         "size": uint,
     },
     size_is_length,
@@ -761,7 +760,7 @@ runs_schema = intersect(
                     "spsa_params?": {
                         "start": uint,
                         "iter": uint,
-                        "packed_flips": Binary,  # TODO: check length
+                        "packed_flips": bytes,  # TODO: check length
                     },
                     "worker_info": worker_info_schema_runs,
                 },

--- a/server/utils/clone_fish.py
+++ b/server/utils/clone_fish.py
@@ -3,7 +3,6 @@
 import bz2
 
 import requests
-from bson.binary import Binary
 from pymongo import ASCENDING, MongoClient
 
 # fish_host = 'http://localhost:6543'
@@ -44,9 +43,7 @@ def main():
                     run = requests.get(fish_host + "/api/get_run/" + run_id).json()
                     runs.insert(run)
                 pgn = requests.get(fish_host + "/api/pgn/" + pgn_file)
-                pgndb.insert(
-                    dict(pgn_bz2=Binary(bz2.compress(pgn.content)), run_id=pgn_file)
-                )
+                pgndb.insert(dict(pgn_bz2=bz2.compress(pgn.content), run_id=pgn_file))
                 loaded[pgn_file] = True
                 count += 1
         skip += len(pgn_list)


### PR DESCRIPTION
The Binary wrapper (with subtype 0) seems to stem from the days that Python made no distinction between strings and byte arrays. I checked that wrapping a byte array with Binary makes no difference in the resulting bson encoding. Moreover a Binary wrapper is directly decoded as bytes and not as a Binary wrapper.

Solves:

https://tests.stockfishchess.org/actions?max_actions=1&action=log_message&user=&text=&before=1740938754.68217&run_id=