### PR TITLE
Move base diff link to "base branch not same as master" card

### DIFF
--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -276,7 +276,7 @@
           </div>
         % elif 'spsa' not in run['args']:
           <div id="master-diff" class="alert alert-danger mb-2">
-            Base branch not same as Stockfish master
+            Base branch not same as Stockfish master: <a class="alert-link" href="${h.master_diff_url(run)}" target="_blank" rel="noopener">diff</a>
           </div>
         % endif
       % endif
@@ -291,12 +291,6 @@
       % if 'spsa' not in run['args'] and run['args']['base_signature'] == run['args']['new_signature']:
         <div class="alert alert-info mb-2">
           Note: The new signature is the same as base signature.
-        </div>
-      % endif
-
-      % if 'spsa' not in run['args'] and not run.get('base_same_as_master'):
-        <div class="alert alert-warning">
-          <a class="alert-link" href="${h.master_diff_url(run)}" target="_blank" rel="noopener">Master diff</a>
         </div>
       % endif
 


### PR DESCRIPTION
Here is how it looks now:

![Screenshot from 2025-03-17 18-12-29](https://github.com/user-attachments/assets/7c1b3d79-db17-4b76-9fc2-d51403c042a5)

Before

![image](https://github.com/user-attachments/assets/a61e1cca-2568-4d82-ba84-a51bc598337f)
