### PR TITLE
Combine all warnings in a single card.

### DIFF
--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -269,22 +269,14 @@
           </div>
       % endif
 
-      % if run.get('base_same_as_master') is not None:
-        % if run['base_same_as_master']:
-          <div id="master-diff" class="alert alert-success">
-            Base branch same as Stockfish master
-          </div>
-        % elif 'spsa' not in run['args']:
-          <div id="master-diff" class="alert alert-danger mb-2">
-            Base branch not same as Stockfish master: <a class="alert-link" href="${h.master_diff_url(run)}" target="_blank" rel="noopener">diff</a>
-          </div>
-        % endif
-      % endif
-
-      % if warnings != "":
-        <div class="alert alert-warning">
-          Warning: </br>
-          ${warnings|n}
+      % if warnings != []:
+        <div class="alert alert-danger">
+          % for idx, warning in enumerate(warnings):
+            ${warning|n}
+            % if idx != len(warnings)-1:
+              <hr style="margin: 0.3em auto;">
+            % endif
+          % endfor
         </div>
       % endif
 

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import bson
 import fishtest.stats.stat_util
 import requests
+from fishtest.helpers import master_diff_url
 from fishtest.run_cache import Prio
 from fishtest.schemas import RUN_VERSION, runs_schema, short_worker_name
 from fishtest.util import (
@@ -1624,8 +1625,10 @@ def tests_view(request):
     # Check for run["failed"] for backward compatibility
     if run["failed"] or run.get("failures", 0) > 0:
         warnings.append("This is a failed test.")
-
-    warnings = "</br>".join(warnings)
+    base_same_as_master = run.get("base_same_as_master", True)
+    if not base_same_as_master and "spsa" not in run["args"]:
+        anchor = f'<a class="alert-link" href="{master_diff_url(run)}" target="_blank" rel="noopener">diff</a>'
+        warnings.append(f"The base branch is different from master: {anchor}")
 
     return {
         "run": run,


### PR DESCRIPTION
This is part of an attempt to better structure the various bits of information on the test page that may affect the approval decision.

Here is what this PR looks like when all warnings occur:

![Screenshot from 2025-03-19 19-58-26](https://github.com/user-attachments/assets/3855979e-a0c1-40e3-b8d8-148eba6f93d5)
