### PR TITLE
Salvage engine binaries compiled with ARCH=native

### DIFF
--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,5 @@
+<<<<<<< HEAD
 {"__version": 272, "updater.py": "eWhuI9NHh+Ktx8lUfu5g3uu3h5ekFo4YCmxneKM35NYi4opHRaJEYN9aaofaN4nD", "worker.py": "rofHCY2xKF7RyAk0TyKq1pthrNrR+kZML9rk7yWdaJAE4DpzDcLqrL0d8sH0pRNJ", "games.py": "wrWBvBXy/AzhzaJvKR1LSasmq0vlgB13zgXSxz4SfOiQNyxN5lvhEc90JQt1l+TG"}
+=======
+{"__version": 272, "updater.py": "aV4Jp1H2fi3/CNDyKVXKbUadR2QIP5iYUXXRhdIqrNMFvlv2cuANa6zigKPeqNMo", "worker.py": "rofHCY2xKF7RyAk0TyKq1pthrNrR+kZML9rk7yWdaJAE4DpzDcLqrL0d8sH0pRNJ", "games.py": "wrWBvBXy/AzhzaJvKR1LSasmq0vlgB13zgXSxz4SfOiQNyxN5lvhEc90JQt1l+TG"}
+>>>>>>> 8e5089e1 (Salvage recently accessed network and book files on worker update)

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,5 +1,1 @@
-<<<<<<< HEAD
-{"__version": 272, "updater.py": "eWhuI9NHh+Ktx8lUfu5g3uu3h5ekFo4YCmxneKM35NYi4opHRaJEYN9aaofaN4nD", "worker.py": "rofHCY2xKF7RyAk0TyKq1pthrNrR+kZML9rk7yWdaJAE4DpzDcLqrL0d8sH0pRNJ", "games.py": "wrWBvBXy/AzhzaJvKR1LSasmq0vlgB13zgXSxz4SfOiQNyxN5lvhEc90JQt1l+TG"}
-=======
-{"__version": 272, "updater.py": "aV4Jp1H2fi3/CNDyKVXKbUadR2QIP5iYUXXRhdIqrNMFvlv2cuANa6zigKPeqNMo", "worker.py": "rofHCY2xKF7RyAk0TyKq1pthrNrR+kZML9rk7yWdaJAE4DpzDcLqrL0d8sH0pRNJ", "games.py": "wrWBvBXy/AzhzaJvKR1LSasmq0vlgB13zgXSxz4SfOiQNyxN5lvhEc90JQt1l+TG"}
->>>>>>> 8e5089e1 (Salvage recently accessed network and book files on worker update)
+{"__version": 272, "updater.py": "9tqz4R48SaK1Ybey1+6pqfMbcbhwjP8x0jDjTrye33bUD9AAdMPytlrGjPfKofYr", "worker.py": "rofHCY2xKF7RyAk0TyKq1pthrNrR+kZML9rk7yWdaJAE4DpzDcLqrL0d8sH0pRNJ", "games.py": "edBHu5SmivFWPZpxMxkw0kc6pPuCAcNSfTWrk316QmKpCzmrkElr73KOEaS29Zjh"}

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 272, "updater.py": "PLWj7cnPP4rG8g5R5bJV0Za4kZpuRxbpcpebyFByXeFDUtfat/gfBn/0kJBMOY/m", "worker.py": "rofHCY2xKF7RyAk0TyKq1pthrNrR+kZML9rk7yWdaJAE4DpzDcLqrL0d8sH0pRNJ", "games.py": "eOhVjSokWUJpxYZX1Nx0ph3HXNZxGGm5SV3z15OiHgbUrHTnrZN+/UD6NiBjeNwJ"}
+{"__version": 272, "updater.py": "eWhuI9NHh+Ktx8lUfu5g3uu3h5ekFo4YCmxneKM35NYi4opHRaJEYN9aaofaN4nD", "worker.py": "rofHCY2xKF7RyAk0TyKq1pthrNrR+kZML9rk7yWdaJAE4DpzDcLqrL0d8sH0pRNJ", "games.py": "wrWBvBXy/AzhzaJvKR1LSasmq0vlgB13zgXSxz4SfOiQNyxN5lvhEc90JQt1l+TG"}

--- a/worker/updater.py
+++ b/worker/updater.py
@@ -108,11 +108,13 @@ def update(restart=True, test=False):
                     sep="",
                     file=sys.stderr,
                 )
-        # Preserve some old files
+        # Preserve/delete some old files
         backup_pattern = (
             # (pattern, num_bkps, expiration_in_days)
             ("fastchess.exe" if IS_WINDOWS else "fastchess", 1, math.inf),
+            ("stockfish-*-native", 40, 30),
             ("nn-*.nnue", 10, 30),
+            ("results-*.pgn", 0, -1),
             ("*.epd", 4, 30),
             ("*.pgn", 4, 30),
         )


### PR DESCRIPTION
(PR on top of #2275)
    
Salvaging such binaries is completely safe. To mark an engine as natively compiled (all recent stockfishes) we append `-native` to the name of the binary.
    
To achieve this we refactor `setup_engine` and simplify its use.
    
Also: we delete the left over files with names `results-xx...xx.pgn` on worker update.
