### PR TITLE
Update min GCC to 9.3 and Clang to 10.0

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -35,7 +35,7 @@ Proper configuration of `nginx` is crucial for this, and should be done
 according to the route/URL mapping defined in `__init__.py`.
 """
 
-WORKER_VERSION = 274
+WORKER_VERSION = 275
 
 
 @exception_view_config(HTTPException)

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 274, "updater.py": "eWhuI9NHh+Ktx8lUfu5g3uu3h5ekFo4YCmxneKM35NYi4opHRaJEYN9aaofaN4nD", "worker.py": "+50DtQZ8Hv4+ByRuorGg9tBApB5TxuWhE/PUT1j4YsnlTzANBgTziO7XTo3ESOrQ", "games.py": "wrWBvBXy/AzhzaJvKR1LSasmq0vlgB13zgXSxz4SfOiQNyxN5lvhEc90JQt1l+TG"}
+{"__version": 275, "updater.py": "eWhuI9NHh+Ktx8lUfu5g3uu3h5ekFo4YCmxneKM35NYi4opHRaJEYN9aaofaN4nD", "worker.py": "rwR20qCZbwZIwMMVO0KJavsHPYuWuNb391xqaAoOhqt+pIjmTDr8eD5onRvE4fTH", "games.py": "wrWBvBXy/AzhzaJvKR1LSasmq0vlgB13zgXSxz4SfOiQNyxN5lvhEc90JQt1l+TG"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -63,15 +63,15 @@ from updater import update
 LOCK_FILE = Path(__file__).resolve().parent / "fishtest_worker.lock"
 
 # Minimum requirement of compiler version for Stockfish.
-MIN_GCC_MAJOR = 7
+MIN_GCC_MAJOR = 9
 MIN_GCC_MINOR = 3
 
-MIN_CLANG_MAJOR = 8
+MIN_CLANG_MAJOR = 10
 MIN_CLANG_MINOR = 0
 
 FASTCHESS_SHA = "f8e58066992e5e130f07fb3ba49b89b603e32f21"
 
-WORKER_VERSION = 274
+WORKER_VERSION = 275
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0


### PR DESCRIPTION
I propose we update the GCC and Clang minimum required version to 9.3 and 10.0 to slowly force users with very old systems to update their compilers.

gcc 9.3 has been chosen as the minimum version for gcc since it is the at the time of writing the oldest used version (by noob).

clang 10.0 has been chosen since it almost matches the release date of gcc 9.3 (gcc March 12, 2020 vs clang 24 Mar 2020).

At the time of writing there are no active clang contributors.