### PR TITLE
Show engine option mismatch warning also for SPSA tests

### DIFF
--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -1643,7 +1643,7 @@ def tests_view(request):
         warnings.append("priority exceeds the normal limit")
     if not reasonable_run_hashes(run):
         warnings.append("hash options are too low or too high for this TC")
-    if not same_options and "spsa" not in run["args"]:
+    if not same_options:
         warnings.append("base options differ from new options")
     if (f := run.get("failures", 0)) > 0:
         warnings.append(f"this test had {f} {plural(f, 'failure')}")


### PR DESCRIPTION
The "Base engine options are not the same..." warning is currently suppressed for SPSA tests.
This hides potential configuration errors (e.g., different Hash values) that can invalidate SPSA results and waste resources.

This should help developers and approvers quickly identify option mismatches (especially Hash) in SPSA tests, improving test validity and preventing wasted resources.

A practical example of where this lack of warning caused confusion can be seen in test:
https://tests.stockfishchess.org/tests/view/67f8f1fc5bd14afa3759ebbe

In this SPSA test, the Hash values were unintentionally different (32 vs 16). This discrepancy was not flagged by the UI warning, delaying its identification by both the submitter and the approver. Had the warning been present for SPSA tests, this common type of setup issue might have been caught much earlier, potentially saving time and resources.