### PR TITLE
Check book checksums

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -35,7 +35,7 @@ Proper configuration of `nginx` is crucial for this, and should be done
 according to the route/URL mapping defined in `__init__.py`.
 """
 
-WORKER_VERSION = 276
+WORKER_VERSION = 277
 
 
 @exception_view_config(HTTPException)

--- a/worker/games.py
+++ b/worker/games.py
@@ -1491,7 +1491,8 @@ def run_games(
 
         print(f"Book sri mismatch: {book_sri} != {sri}.", file=sys.stderr)
         if downloaded_book:
-            raise WorkerException(f"Failed to match sri for book {book}")
+            print(f"Failed to match sri for book {book}. Ignoring!", file=sys.stderr)
+            break
 
         try:
             (testing_dir / book).unlink()

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 276, "updater.py": "+i4UI6vDlgNrZ/A/mCOGN820HJX2L896A75KKbGT10DeOXJQwwsleqEzNJpdysou", "worker.py": "nr3Dz7DJ0b69FVQ3QQ3iL/tNbbOklUH6uS50WGW75HwBzgxPzJLxXBKJrEob+4i/", "games.py": "IQMDSd55VldF72RZRCTMTZF8yFFM6exjifkw2y2Cy85bwfAk3Z90/CvAnUFUmOJH"}
+{"__version": 277, "updater.py": "+i4UI6vDlgNrZ/A/mCOGN820HJX2L896A75KKbGT10DeOXJQwwsleqEzNJpdysou", "worker.py": "/rCUxFppJC7Z2P/131O06GGMkC9uOTUVge4vVf8Ee1J2p7Ft+ftUmJkCxHeBdXOc", "games.py": "Qb73cZSQov6P3gAQA0MXYxs9QkbvfTkf+If5HjtBbMPNDfKJvh8sWrxz1Xh1JCtX"}

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 277, "updater.py": "+i4UI6vDlgNrZ/A/mCOGN820HJX2L896A75KKbGT10DeOXJQwwsleqEzNJpdysou", "worker.py": "/rCUxFppJC7Z2P/131O06GGMkC9uOTUVge4vVf8Ee1J2p7Ft+ftUmJkCxHeBdXOc", "games.py": "Qb73cZSQov6P3gAQA0MXYxs9QkbvfTkf+If5HjtBbMPNDfKJvh8sWrxz1Xh1JCtX"}
+{"__version": 277, "updater.py": "+gmXcz2uUk2qGRMXQ2Eav7MIHyC98SBPfk+dJQd2Qu2Rst6Rp5obkBlB/AqH2QPQ", "worker.py": "/rCUxFppJC7Z2P/131O06GGMkC9uOTUVge4vVf8Ee1J2p7Ft+ftUmJkCxHeBdXOc", "games.py": "gBbh+shKwmyJYkY7tpwJtosbELSKO5yKyQf81jLo15LpKLiRj6bNojApd1c+SEOM"}

--- a/worker/updater.py
+++ b/worker/updater.py
@@ -106,8 +106,8 @@ def update(restart=True, test=False):
             ("stockfish-*" + EXE_SUFFIX, 50, 30),
             ("nn-*.nnue", 10, 30),
             ("results-*.pgn", 0, -1),
-            ("*.epd", 4, 30),
-            ("*.pgn", 4, 30),
+            ("*.epd", 4, 365),
+            ("*.pgn", 4, 365),
         )
         for pattern, num_bkps, expiration_days in backup_pattern:
             expiration_time = time.time() - 24 * 3600 * expiration_days

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -56,6 +56,7 @@ from games import (
     run_games,
     send_api_post_request,
     str_signal,
+    text_hash,
     unzip,
 )
 from updater import update
@@ -71,7 +72,7 @@ MIN_CLANG_MINOR = 0
 
 FASTCHESS_SHA = "f8e58066992e5e130f07fb3ba49b89b603e32f21"
 
-WORKER_VERSION = 276
+WORKER_VERSION = 277
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0
@@ -229,13 +230,6 @@ def safe_sleep(f):
         time.sleep(f)
     except Exception:
         print("\nSleep interrupted...")
-
-
-def text_hash(file):
-    # text mode to have newline translation!
-    return base64.b64encode(
-        hashlib.sha384(file.read_text().encode("utf8")).digest()
-    ).decode("utf8")
 
 
 def generate_sri(install_dir):


### PR DESCRIPTION
For some time now the books repo provides checksums for our books in a json file, and these are now available from the server via the `book_sri` key.

This PR makes the worker check the validity of a book before it is being used.

At the moment the logic is as follows:
* if a book is found, and the checksum fails, we delete the book, download it once and re-test the checksum
* if a book was downloaded and the checksum fails, an error message is printed, but the worker continues as normal
* if we fail to obtain the `book_sri` information from the server, the worker prints an error message and continues as normal

We also raise the "expiration" time of local book files in `updater.py` to 365 days since they were last accessed (up from 30 days).