### PR TITLE
Workaround for failing GitHub api call until true cause found.

### DIFF
--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -1014,7 +1014,13 @@ def validate_form(request):
     master_diff = requests.get(
         api_url, headers={"Accept": "application/vnd.github+json"}
     )
-    merge_base_commit = master_diff.json()["merge_base_commit"]["sha"]
+    merge_base_commit = data["resolved_base"]
+    json = None
+    try:
+        json = master_diff.json()
+        merge_base_commit = json["merge_base_commit"]["sha"]
+    except Exception as e:
+        print(f"Api call {api_url} failed: {str(e)}. Result = {json}", flush=True)
     data["merge_base_commit"] = merge_base_commit
 
     # Store nets info


### PR DESCRIPTION
See the discussion in #2293.

I have theory why the call fails, but no time to test it now (need to prepare some conference talks). 

In case the call fails, I am logging the result. Hopefully this will make things clearer.