### PR TITLE
One more fix in dealing with #2309

### DIFF
--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -895,6 +895,17 @@ def validate_form(request):
         "info": request.POST["run-info"],
     }
     try:
+        # Deal with people that have changed their GitHub username
+        # but still use the old repo url
+        r = requests.head(data["tests_repo"], allow_redirects=True)
+        r.raise_for_status()
+        data["tests_repo"] = r.url
+    except Exception as e:
+        raise Exception(
+            f"Unable to access developer repository {data['tests_repo']}: {str(e)}"
+        ) from e
+
+    try:
         data["master_sha"] = get_master_sha(
             data["tests_repo"].replace(
                 "https://github.com", "https://api.github.com/repos"


### PR DESCRIPTION
See https://github.com/official-stockfish/fishtest/pull/2310#issuecomment-2961779417

A Stockfish developer can change their GitHub username. The old url of the developer fork continues to work and is forwarded to the new url.

However the old username can no longer be used to refer to commits in the fork and this leads to bugs.

In this PR we replace the outdated repo url with the most current one.