### PR TITLE
fix(tests_view.mak): correct ReferenceError

### DIFF
--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -853,7 +853,7 @@
 
     const diffNew  = "${run["args"]["resolved_new"][:10]}";
     const apiOfficialMaster = "https://api.github.com/repos/official-stockfish/Stockfish";
-    const baseOfficialMaster = request.rundb.official_master_sha;
+    const baseOfficialMaster = ${json.dumps(request.rundb.official_master_sha) | n};
 
     % if run["args"].get("spsa"):
       const apiUrlBase = apiOfficialMaster;


### PR DESCRIPTION
The `handleDiff` function in the tests view template was causing a `ReferenceError: request is not defined` on the client-side.

This was because the `baseOfficialMaster` JavaScript variable was being assigned directly from the server-side `request` object, which is not available in the browser's scope.

This commit resolves the error by using Mako's `${...}` syntax with `json.dumps` to properly serialize the `request.rundb.official_master_sha` value from the server and inject it into the JavaScript code. This ensures the value is correctly handled,
including cases where it might be `None`.