### PR TITLE
Remove the rate limit check in is_master

### DIFF
--- a/server/fishtest/github_api.py
+++ b/server/fishtest/github_api.py
@@ -126,12 +126,6 @@ def _is_master(sha, official_master_sha):
 
 def is_master(sha):
     try:
-        # Non sha arguments cannot be safely cached
-        validate(sha_schema, sha)
-        # Protect against DOS'ing
-        rate_limit_ = rate_limit()
-        if rate_limit_["used"] > rate_limit_["remaining"]:
-            raise Exception(r"Rate limit more than 50% consumed.")
         return _is_master(sha, _official_master_sha)
     except Exception as e:
         print(f"Unable to evaluate is_master({sha}): {str(e)}", flush=True)

--- a/server/fishtest/github_api.py
+++ b/server/fishtest/github_api.py
@@ -10,13 +10,25 @@ from vtjson import validate
 TIMEOUT = 3
 
 _official_master_sha = None
+_github_rate_limit = -1
+
+
+def call(url, *args, **kwargs):
+    global _github_rate_limit
+    r = requests.get(url, *args, **kwargs)
+    resource = r.headers.get("X-RateLimit-Resource", "")
+    if resource == "core":
+        _github_rate_limit = int(
+            r.headers.get("X-RateLimit-Remaining", _github_rate_limit)
+        )
+    return r
 
 
 def _download_from_github_raw(
     item, user="official-stockfish", repo="Stockfish", branch="master"
 ):
     item_url = f"https://raw.githubusercontent.com/{user}/{repo}/{branch}/{item}"
-    r = requests.get(item_url, timeout=TIMEOUT)
+    r = call(item_url, timeout=TIMEOUT)
     r.raise_for_status()
     return r.content
 
@@ -27,10 +39,10 @@ def _download_from_github_api(
     item_url = (
         f"https://api.github.com/repos/{user}/{repo}/contents/{item}?ref={branch}"
     )
-    r = requests.get(item_url, timeout=TIMEOUT)
+    r = call(item_url, timeout=TIMEOUT)
     r.raise_for_status()
     git_url = r.json()["git_url"]
-    r = requests.get(git_url, timeout=TIMEOUT)
+    r = call(git_url, timeout=TIMEOUT)
     r.raise_for_status()
     return base64.b64decode(r.json()["content"])
 
@@ -48,7 +60,7 @@ def download_from_github(
 
 def get_commit(user="official-stockfish", repo="Stockfish", branch="master"):
     url = f"https://api.github.com/repos/{user}/{repo}/commits/{branch}"
-    r = requests.get(url, timeout=TIMEOUT)
+    r = call(url, timeout=TIMEOUT)
     r.raise_for_status()
     commit = r.json()
     return commit
@@ -56,7 +68,7 @@ def get_commit(user="official-stockfish", repo="Stockfish", branch="master"):
 
 def get_commits(user="official-stockfish", repo="Stockfish"):
     url = f"https://api.github.com/repos/{user}/{repo}/commits"
-    r = requests.get(url, timeout=TIMEOUT)
+    r = call(url, timeout=TIMEOUT)
     r.raise_for_status()
     commit = r.json()
     return commit
@@ -64,7 +76,7 @@ def get_commits(user="official-stockfish", repo="Stockfish"):
 
 def rate_limit():
     url = "https://api.github.com/rate_limit"
-    r = requests.get(url, timeout=TIMEOUT)
+    r = call(url, timeout=TIMEOUT)
     r.raise_for_status()
     rate_limit = r.json()["resources"]["core"]
     return rate_limit
@@ -77,8 +89,7 @@ def compare_sha(user1="official-stockfish", sha1=None, user2=None, sha2=None):
     validate(sha_schema, sha2)
 
     # Protect against DOS'ing
-    rate_limit_ = rate_limit()
-    if rate_limit_["used"] > rate_limit_["remaining"]:
+    if _github_rate_limit < 2500:
         raise Exception(r"Rate limit more than 50% consumed.")
 
     if user2 is None:
@@ -87,9 +98,7 @@ def compare_sha(user1="official-stockfish", sha1=None, user2=None, sha2=None):
         "https://api.github.com/repos/official-stockfish/"
         f"Stockfish/compare/{user1}:{sha1}...{user2}:{sha2}"
     )
-    r = requests.get(
-        url, headers={"Accept": "application/vnd.github+json"}, timeout=TIMEOUT
-    )
+    r = call(url, headers={"Accept": "application/vnd.github+json"}, timeout=TIMEOUT)
     r.raise_for_status()
     return r.json()
 


### PR DESCRIPTION
It is already performed deeper in the call chain.

I noticed this because after #2332 suddenly test pages take a long time to load, even when all github api calls are cached. 

In a second commit we remove the explicit invocation of the rate limit api.