### PR TITLE
More refactorings of github_api calls

### DIFF
--- a/server/fishtest/github_api.py
+++ b/server/fishtest/github_api.py
@@ -1,21 +1,71 @@
 import base64
-from functools import lru_cache
 from pathlib import Path
 from urllib.parse import urlparse
 
 import requests
+from fishtest.lru_cache import LRUCache
 from fishtest.schemas import sha as sha_schema
 from vtjson import validate
 
+"""
+We treat this module as a singleton.
+"""
+"""
+Note: we generally don't suppress exceptions since too many things can
+go wrong. The caller should gracefully handle whatever comes their
+way.
+"""
+GITHUB_API_VERSION = 1
 TIMEOUT = 3
+INITIAL_RATELIMIT = 5000
+LRU_CACHE_SIZE = 6000
 
+_github_rate_limit = None
+_lru_cache = None
+_kvstore = None
+
+# This one is set externally
 _official_master_sha = None
-_github_rate_limit = -1
 
 
-def call(url, *args, **kwargs):
+def init(kvstore):
+    global _github_rate_limit, _kvstore, _lru_cache
+    _kvstore = kvstore
+    _lru_cache = LRUCache(LRU_CACHE_SIZE)
+    github_api_cache = {"version": GITHUB_API_VERSION, "lru_cache": []}
+    try:
+        if "github_api_cache" in _kvstore:
+            github_api_cache = _kvstore["github_api_cache"]
+        else:
+            print("Initializing github_api_cache", flush=True)
+        if github_api_cache["version"] != GITHUB_API_VERSION:
+            raise Exception("Stored github_api_cache has different version")
+        for k, v in github_api_cache["lru_cache"]:
+            _lru_cache[tuple(k)] = v
+    except Exception as e:
+        print(f"Unable to restore github_api_cache from kvstore: {str(e)}", flush=True)
+    try:
+        _github_rate_limit = rate_limit()["remaining"]
+    except Exception as e:
+        print(
+            f"Unable to initialize github rate limit :{str(e)}. Assuming {INITIAL_RATELIMIT}."
+        )
+
+
+def save():
+    global _kvstore
+    _kvstore["github_api_cache"] = {
+        "version": GITHUB_API_VERSION,
+        "lru_cache": [(k, v) for k, v in _lru_cache.items()],
+    }
+
+
+def call(url, *args, _method="GET", _ignore_rate_limit=False, **kwargs):
     global _github_rate_limit
-    r = requests.get(url, *args, **kwargs)
+    if not _ignore_rate_limit and _github_rate_limit < INITIAL_RATELIMIT / 2:
+        raise Exception(r"Rate limit more than 50% consumed.")
+
+    r = requests.request(_method, url, *args, **kwargs)
     resource = r.headers.get("X-RateLimit-Resource", "")
     if resource == "core":
         _github_rate_limit = int(
@@ -28,47 +78,67 @@ def _download_from_github_raw(
     item, user="official-stockfish", repo="Stockfish", branch="master"
 ):
     item_url = f"https://raw.githubusercontent.com/{user}/{repo}/{branch}/{item}"
-    r = call(item_url, timeout=TIMEOUT)
+    r = call(item_url, timeout=TIMEOUT, _ignore_rate_limit=True)
     r.raise_for_status()
     return r.content
 
 
 def _download_from_github_api(
-    item, user="official-stockfish", repo="Stockfish", branch="master"
+    item,
+    user="official-stockfish",
+    repo="Stockfish",
+    branch="master",
+    ignore_rate_limit=False,
 ):
     item_url = (
         f"https://api.github.com/repos/{user}/{repo}/contents/{item}?ref={branch}"
     )
-    r = call(item_url, timeout=TIMEOUT)
+    r = call(item_url, timeout=TIMEOUT, _ignore_rate_limit=ignore_rate_limit)
     r.raise_for_status()
     git_url = r.json()["git_url"]
-    r = call(git_url, timeout=TIMEOUT)
+    r = call(git_url, timeout=TIMEOUT, _ignore_rate_limit=True)
     r.raise_for_status()
     return base64.b64decode(r.json()["content"])
 
 
 def download_from_github(
-    item, user="official-stockfish", repo="Stockfish", branch="master", method="api"
+    item,
+    user="official-stockfish",
+    repo="Stockfish",
+    branch="master",
+    method="api",
+    ignore_rate_limit=False,
 ):
     if method == "api":
-        return _download_from_github_api(item, user=user, repo=repo, branch=branch)
+        return _download_from_github_api(
+            item,
+            user=user,
+            repo=repo,
+            branch=branch,
+            ignore_rate_limit=ignore_rate_limit,
+        )
     elif method == "raw":
         return _download_from_github_raw(item, user=user, repo=repo, branch=branch)
     else:
         raise ValueError(f"Unknown method {method}")
 
 
-def get_commit(user="official-stockfish", repo="Stockfish", branch="master"):
+def get_commit(
+    user="official-stockfish",
+    repo="Stockfish",
+    branch="master",
+    ignore_rate_limit=False,
+):
     url = f"https://api.github.com/repos/{user}/{repo}/commits/{branch}"
-    r = call(url, timeout=TIMEOUT)
+    r = call(url, timeout=TIMEOUT, _ignore_rate_limit=ignore_rate_limit)
     r.raise_for_status()
     commit = r.json()
     return commit
 
 
-def get_commits(user="official-stockfish", repo="Stockfish"):
+def get_commits(user="official-stockfish", repo="Stockfish", ignore_rate_limit=False):
     url = f"https://api.github.com/repos/{user}/{repo}/commits"
-    r = call(url, timeout=TIMEOUT)
+    r = call(url, timeout=TIMEOUT, _ignore_rate_limit=ignore_rate_limit)
     r.raise_for_status()
     commit = r.json()
     return commit
@@ -76,31 +146,49 @@ def get_commits(user="official-stockfish", repo="Stockfish"):
 
 def rate_limit():
     url = "https://api.github.com/rate_limit"
-    r = call(url, timeout=TIMEOUT)
+    r = call(url, timeout=TIMEOUT, _ignore_rate_limit=True)
     r.raise_for_status()
     rate_limit = r.json()["resources"]["core"]
     return rate_limit
 
 
-@lru_cache(maxsize=1000)
-def compare_sha(user1="official-stockfish", sha1=None, user2=None, sha2=None):
+def compare_sha(
+    user1="official-stockfish",
+    sha1=None,
+    user2=None,
+    sha2=None,
+    ignore_rate_limit=False,
+):
+    global _lru_cache
     # Non sha arguments cannot be safely cached
     validate(sha_schema, sha1)
     validate(sha_schema, sha2)
 
-    # Protect against DOS'ing
-    if _github_rate_limit < 2500:
-        raise Exception(r"Rate limit more than 50% consumed.")
-
     if user2 is None:
         user2 = user1
+
+    # it's not necessary to include user1, user2 as shas
+    # are globally unique
+    inputs = ("compare_sha", sha1, sha2)
+    if inputs in _lru_cache:
+        return _lru_cache[inputs]
     url = (
         "https://api.github.com/repos/official-stockfish/"
         f"Stockfish/compare/{user1}:{sha1}...{user2}:{sha2}"
     )
-    r = call(url, headers={"Accept": "application/vnd.github+json"}, timeout=TIMEOUT)
+    r = call(
+        url,
+        headers={"Accept": "application/vnd.github+json"},
+        timeout=TIMEOUT,
+        _ignore_rate_limit=ignore_rate_limit,
+    )
     r.raise_for_status()
-    return r.json()
+    json = r.json()
+    json1 = {}
+    json1["merge_base_commit"] = {}
+    json1["merge_base_commit"]["sha"] = json["merge_base_commit"]["sha"]
+    _lru_cache[inputs] = json1
+    return json1
 
 
 def parse_repo(repo_url):
@@ -108,53 +196,83 @@ def parse_repo(repo_url):
     return (p[1], p[2])
 
 
-def get_merge_base_commit(user1="official-stockfish", sha1=None, user2=None, sha2=None):
+def get_merge_base_commit(
+    user1="official-stockfish",
+    sha1=None,
+    user2=None,
+    sha2=None,
+    ignore_rate_limit=False,
+):
     if user2 is None:
         user2 = user1
-    master_diff = compare_sha(user1=user1, sha1=sha1, user2=user2, sha2=sha2)
+    master_diff = compare_sha(
+        user1=user1,
+        sha1=sha1,
+        user2=user2,
+        sha2=sha2,
+        ignore_rate_limit=ignore_rate_limit,
+    )
     return master_diff["merge_base_commit"]["sha"]
 
 
-def is_ancestor(user1="official-stockfish", sha1=None, user2=None, sha2=None):
+def is_ancestor(
+    user1="official-stockfish",
+    sha1=None,
+    user2=None,
+    sha2=None,
+    ignore_rate_limit=False,
+):
     if user2 is None:
         user2 = user1
     merge_base_commit = get_merge_base_commit(
-        user1=user1, sha1=sha1, user2=user2, sha2=sha2
+        user1=user1,
+        sha1=sha1,
+        user2=user2,
+        sha2=sha2,
+        ignore_rate_limit=ignore_rate_limit,
     )
     return merge_base_commit == sha1
 
 
-@lru_cache(maxsize=1000)
-def _is_master(sha, official_master_sha):
+def _is_master(sha, official_master_sha, ignore_rate_limit=False):
+    global _lru_cache
+    inputs = ("_is_master", sha, official_master_sha)
+    if inputs in _lru_cache:
+        return _lru_cache[inputs]
     try:
-        return is_ancestor(sha1=sha, sha2=official_master_sha)
+        ret = is_ancestor(
+            sha1=sha, sha2=official_master_sha, ignore_rate_limit=ignore_rate_limit
+        )
     except requests.HTTPError as e:
         if e.response.status_code == 404:
-            return False
+            ret = False
+            # Positive answers are already cached in compare_sha
+            _lru_cache[inputs] = ret
+    return ret
 
 
-def is_master(sha):
-    try:
-        return _is_master(sha, _official_master_sha)
-    except Exception as e:
-        print(f"Unable to evaluate is_master({sha}): {str(e)}", flush=True)
-        return False
+def is_master(sha, ignore_rate_limit=False):
+    return _is_master(sha, _official_master_sha, ignore_rate_limit=ignore_rate_limit)
 
 
-def get_master_repo(user="official-stockfish", repo="Stockfish"):
+def get_master_repo(
+    user="official-stockfish", repo="Stockfish", ignore_rate_limit=False
+):
     api_url = f"https://api.github.com/repos/{user}/{repo}"
-    r = call(api_url, timeout=TIMEOUT)
+    r = call(api_url, timeout=TIMEOUT, _ignore_rate_limit=ignore_rate_limit)
     r.raise_for_status()
     r = r.json()
     while True:
-        if "fork" not in r:
-            return None
         if not r["fork"]:
-            return r.get("html_url", None)
+            return r["html_url"]
         else:
-            if "parent" not in r:
-                return None
             r = r["parent"]
+
+
+def normalize_repo(repo):
+    r = call(repo, _method="HEAD", allow_redirects=True, _ignore_rate_limit=True)
+    r.raise_for_status()
+    return r.url
 
 
 def compare_branches_url(

--- a/server/fishtest/lru_cache.py
+++ b/server/fishtest/lru_cache.py
@@ -1,0 +1,22 @@
+from collections import OrderedDict
+
+
+class LRUCache(OrderedDict):
+    def __init__(self, size):
+        super().__init__()
+        self.__size = size
+
+    def __setitem__(self, key, value):
+        super().__setitem__(key, value)
+        if len(self) > self.__size:
+            self.popitem(last=False)
+
+    @property
+    def size(self):
+        return self.__size
+
+    @size.setter
+    def size(self, val):
+        while len(self) > val:
+            self.popitem(last=False)
+        self.__size = val

--- a/server/fishtest/templates/rate_limits.mak
+++ b/server/fishtest/templates/rate_limits.mak
@@ -30,10 +30,9 @@
   <a href="/user"> profile </a>.
 </p>
 <script>
-  async function showRateLimit(elt) {
+  (async () => {
     await DOMContentLoaded();
+    const elt = document.getElementById("client_rate_limit");
     elt.innerHTML = await rateLimit();
-  }
-  const elt = document.getElementById("client_rate_limit");
-  showRateLimit(elt);
+  })();
 </script>

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -592,10 +592,19 @@ def diff_url(run, master_check=True):
         user1 = user2
         sha1 = run["args"]["resolved_base"]
     if master_check:
-        if is_master(sha1):
-            user1 = "official-stockfish"
-        if is_master(sha2):
-            user2 = "official-stockfish"
+        im1 = im2 = False
+        try:
+            im1 = is_master(sha1)
+            im2 = is_master(sha2)
+        except Exception as e:
+            print(
+                f"Unable to evaluate is_master({sha1}) or is_master({sha2}): {str(e)}"
+            )
+        else:
+            if im1:
+                user1 = "official-stockfish"
+            if im2:
+                user2 = "official-stockfish"
     return compare_branches_url(user1=user1, branch1=sha1, user2=user2, branch2=sha2)
 
 

--- a/server/tests/test_run.py
+++ b/server/tests/test_run.py
@@ -10,9 +10,11 @@ class CreateRunTest(unittest.TestCase):
             re.match(
                 r"[1-9]\d{5,7}|None",
                 str(
-                    get_master_info(user="official-stockfish", repo="Stockfish")[
-                        "bench"
-                    ]
+                    get_master_info(
+                        user="official-stockfish",
+                        repo="Stockfish",
+                        ignore_rate_limit=True,
+                    )["bench"]
                 ),
             )
         )


### PR DESCRIPTION
- Always pass exceptions to the caller. There are too many things that can go wrong, to silently suppress such exceptions.

- More idiomatic javascript in rate_limits.mak.

- Home grown LRUCache that better suits our needs. The implementation is a simple wrapper around OrderedDict.

- The cacheing of GitHub api calls is now persistent across server restarts.

- Recent users cannot have DEV repo that is not forked from official-stockfish.