### PR TITLE
Insert move_to_end calls in lru_cache __(get,set)item__()

### DIFF
--- a/server/fishtest/lru_cache.py
+++ b/server/fishtest/lru_cache.py
@@ -8,8 +8,13 @@ class LRUCache(OrderedDict):
 
     def __setitem__(self, key, value):
         super().__setitem__(key, value)
+        self.move_to_end(key)
         if len(self) > self.__size:
             self.popitem(last=False)
+
+    def __getitem__(self, key):
+        self.move_to_end(key)
+        return super().__getitem__(key)
 
     @property
     def size(self):


### PR DESCRIPTION
Without this, it doesn't actually work...