### PR TITLE
Various cleanups

### DIFF
--- a/server/fishtest/templates/rate_limits.mak
+++ b/server/fishtest/templates/rate_limits.mak
@@ -59,7 +59,7 @@
           serverRateLimitDom.style.cssText = "";
           serverResetDom.style.cssText = "";
           lastServerRefreshTime = now;
-	}
+        }
       } catch(e) {
         serverRateLimitDom.style.cssText = errorCSS;
         serverResetDom.style.cssText = errorCSS;
@@ -73,7 +73,7 @@
           clientRateLimitDom.style.cssText = "";
           clientResetDom.style.cssText = "";
           lastClientRefreshTime = now;
-	}
+        }
       } catch(e) {
         clientRateLimitDom.style.cssText = errorCSS;
         clientResetDom.style.cssText = errorCSS;

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -5,12 +5,11 @@ import re
 from datetime import UTC, datetime
 from functools import cache
 
-import fishtest.github_api
+import fishtest.github_api as gh
 import fishtest.stats.stat_util
 import numpy as np
 import scipy.stats
 from email_validator import EmailNotValidError, caching_resolver, validate_email
-from fishtest.github_api import compare_branches_url, is_master, parse_repo
 from zxcvbn import zxcvbn
 
 
@@ -583,19 +582,19 @@ def tests_repo(run):
 
 def diff_url(run, master_check=True):
     tests_repo_ = tests_repo(run)
-    user2, repo = parse_repo(tests_repo_)
+    user2, repo = gh.parse_repo(tests_repo_)
     sha2 = run["args"]["resolved_new"]
     if "spsa" in run["args"]:
         user1 = "official-stockfish"
-        sha1 = fishtest.github_api._official_master_sha
+        sha1 = gh._official_master_sha
     else:
         user1 = user2
         sha1 = run["args"]["resolved_base"]
     if master_check:
         im1 = im2 = False
         try:
-            im1 = is_master(sha1)
-            im2 = is_master(sha2)
+            im1 = gh.is_master(sha1)
+            im2 = gh.is_master(sha2)
         except Exception as e:
             print(
                 f"Unable to evaluate is_master({sha1}) or is_master({sha2}): {str(e)}"
@@ -605,7 +604,7 @@ def diff_url(run, master_check=True):
                 user1 = "official-stockfish"
             if im2:
                 user2 = "official-stockfish"
-    return compare_branches_url(user1=user1, branch1=sha1, user2=user2, branch2=sha2)
+    return gh.compare_branches_url(user1=user1, branch1=sha1, user2=user2, branch2=sha2)
 
 
 def ok_hash(tc_ratio, hash):

--- a/server/tests/test_run.py
+++ b/server/tests/test_run.py
@@ -1,11 +1,15 @@
 import re
 import unittest
 
+import fishtest.github_api as gh
+import util
 from fishtest.views import get_master_info
 
 
 class CreateRunTest(unittest.TestCase):
     def test_10_get_bench(self):
+        rundb = util.get_rundb()
+        gh.init(rundb.kvstore)
         self.assertTrue(
             re.match(
                 r"[1-9]\d{5,7}|None",
@@ -13,7 +17,6 @@ class CreateRunTest(unittest.TestCase):
                     get_master_info(
                         user="official-stockfish",
                         repo="Stockfish",
-                        ignore_rate_limit=True,
                     )["bench"]
                 ),
             )


### PR DESCRIPTION
- Install signal handlers also in secondary instances (bugfix). It seems this code was accidentally disabled in the past. The result of this was that stopping secondary instances was no longer recorded in the event log.

- Make sure that `gitub_api.py` is properly initialized before we use it.

- Initialize `github_api.py` in `__init__.py` rather than in the constructor of `rundb`. We do this only in the primary instance.

- Instead of directly importing methods from `github_api.py` (recall that we think of it as a singleton object) we now do `import fishtest.github_api as gh` and then use `gh.<method>`.

- Create a private method `_update_rate_limit` which does the heavy lifting for keeping `_github_rate_limit` up to date.

- Fix a tab error in `rate_limits.mak`.