### PR TITLE
Hopefully fix for #2358

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -83,7 +83,6 @@ class RunDb:
         self.connections_lock = threading.Lock()
 
         self.books = self.kvstore.get("books", {})
-        self.official_master_sha = self.kvstore.get("official_master_sha", 40 * "f")
         self.worker_runs = self.kvstore.get("worker_runs", {})
 
         self.task_duration = 1800  # 30 minutes

--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -2,6 +2,7 @@
 
 <%!
   import json
+  import fishtest.github_api as gh
   from fishtest.util import diff_url, tests_repo
 %>
 
@@ -842,7 +843,7 @@
 
     const diffNew  = "${run["args"]["resolved_new"][:10]}";
     const apiOfficialMaster = "https://api.github.com/repos/official-stockfish/Stockfish";
-    const baseOfficialMaster = ${json.dumps(request.rundb.official_master_sha) | n};
+    const baseOfficialMaster = ${json.dumps(gh.official_master_sha) | n};
 
     % if run["args"].get("spsa"):
       dots = 3;

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -1709,7 +1709,7 @@ def tests_view(request):
 
     anchor_url = gh.compare_branches_url(
         user1="official-stockfish",
-        branch1=request.rundb.official_master_sha,
+        branch1=gh.official_master_sha,
         user2=user,
         branch2=run["args"]["resolved_base"],
     )
@@ -1736,7 +1736,7 @@ def tests_view(request):
                     warnings.append("base is not an ancestor of new")
                 else:
                     merge_base_commit = gh.get_merge_base_commit(
-                        sha1=request.rundb.official_master_sha,
+                        sha1=gh.official_master_sha,
                         user2=user,
                         sha2=run["args"]["resolved_new"],
                         ignore_rate_limit=irl,


### PR DESCRIPTION
Fishtest keeps track of the official master sha in the variable `gh.official_master_sha`. Unfortunately a left over `rundb.official_master_sha` also exists which is used at a few places instead of the correct `gh.official_master_sha`.

`rundb.official_master_sha` is initialized correctly most of the time, but not updated. This explains why the server suddenly started misbehaving after a master update.

This PR deletes `rundb.official_master_sha`.