### PR TITLE
Log failing API calls to event log.

### DIFF
--- a/server/fishtest/__init__.py
+++ b/server/fishtest/__init__.py
@@ -85,7 +85,7 @@ def main(global_config, **settings):
             # - uses the network;
             # - accesses the db;
             # - starts new threads.
-            gh.init(rundb.kvstore)
+            gh.init(rundb.kvstore, rundb.actiondb)
             rundb.update_aggregated_data()
             rundb.schedule_tasks()
 


### PR DESCRIPTION
Occasionally there are reports of GitHub API calls that fail and then succeed when repeated. E.g.
https://github.com/official-stockfish/fishtest/pull/2293#issuecomment-2956858006

It would be interesting to know how often this occurs. Therefore we now log such events in the event log. We do this by saving certain error replies in the GH API cache but we do not use these entries afterwards. So there is no negative caching. Not at this time anyway.

It is not obvious how to test this PR in real life, but it is tested in `test_github_not_found()` in `test_github_api.py`.