### PR TITLE
misleading comment on SPRT calculator page

### DIFF
--- a/server/fishtest/templates/sprt_calc.mak
+++ b/server/fishtest/templates/sprt_calc.mak
@@ -85,11 +85,11 @@
       more than 95%.
     </li>
     <li>
-      If the Elo model is <b>Logistic</b> then the pass/fail probabilities are
-      independent of the auxiliary data <em>Draw ratio</em> and
-      <em>RMS bias</em>. On the other hand if the Elo model is
-      <b>Normalized</b> then it is the expected duration of the test that is
-      independent of the auxiliary data.
+      If the Elo model is <b>Logistic</b>, both the pass/fail probabilities
+      and the expected test duration are dependent on the auxiliary data
+      (<i>Draw ratio</i> and <i>RMS bias</i>). On the other hand, the
+      <b>Normalized</b> Elo model is designed so that the expected duration
+      of the test is largely independent of this auxiliary data.
     </li>
     <li>
       The <b>Draw ratio</b> is mainly a function of the opening book and the


### PR DESCRIPTION
Isn't this comment wrong? (If I got it wrong, please feel free to close the PR).

The pass/fail probabilities for an SPRT test depend on the drift and variance of the LLR. These properties are directly influenced by the variance of game outcomes, which is heavily dependent on the draw ratio. Therefore, the Logistic model's performance is affected by the draw ratio.

With the new comment, we clarify that the main benefit of the Normalized model is stabilizing the expected test duration, rather than making the test entirely independent of the auxiliary data.

No functional change
