### PR TITLE
Clarify 'signature' fields by adding '(bench)'

### DIFF
--- a/server/fishtest/templates/tests_run.mak
+++ b/server/fishtest/templates/tests_run.mak
@@ -248,7 +248,7 @@
               </div>
 
               <div class="mb-2 col-6">
-                <label for="test-signature" class="form-label">Test Signature</label>
+                <label for="test-signature" class="form-label">Test Signature (bench)</label>
                 <input
                   type="number"
                   name="test-signature"
@@ -262,7 +262,7 @@
               </div>
 
               <div class="mb-2 col-6">
-                <label for="base-signature" class="form-label">Base Signature</label>
+                <label for="base-signature" class="form-label">Base Signature (bench)</label>
                 <input
                   type="number"
                   name="base-signature"

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -1565,6 +1565,12 @@ def tests_view(request):
         if name not in run["args"]:
             continue
 
+        display_name = name
+            if name == "new_signature":
+                display_name = "new_signature (bench)"
+            elif name == "base_signature":
+                display_name = "base_signature (bench)"
+
         value = run["args"][name]
         url = ""
 
@@ -1638,7 +1644,7 @@ def tests_view(request):
         if name == "spsa":
             run_args.append(("spsa", value, ""))
         else:
-            run_args.append((name, html.escape(str(value)), url))
+            run_args.append((display_name, html.escape(str(value)), url))
 
     active = 0
     cores = 0


### PR DESCRIPTION
The terms new_signature and base_signature can be unclear for new users of Fishtest. It is not immediately obvious that these fields are intended for the bench value from Stockfish. This can lead to confusion when creating or reviewing tests.

This PR improves usability by making the purpose of these fields explicit. It appends the suffix (bench) to the labels wherever they appear in the UI.

The updated labels are now:
new_signature (bench)
base_signature (bench)

instead of:
new_signature
base_signature