### PR TITLE
Various fixes

### DIFF
--- a/server/fishtest/static/js/application.js
+++ b/server/fishtest/static/js/application.js
@@ -420,14 +420,17 @@ function loadObject(key) {
   return JSON.parse(value_);
 }
 
-function escapeHtml(unsafe) {
-  return unsafe
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;")
-    .replace(/\n/g, "<br>");
+// Escapes &, <, >, ", '  — idempotently
+function escapeHtml(input) {
+  return (
+    String(input)
+      // & → &amp; (but skip existing entities like &amp; &lt; &#123; &#x1F4A9;)
+      .replace(/&(?!#\d+;|#x[0-9A-Fa-f]+;|\w+;)/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;")
+  );
 }
 
 function handleSortingTables() {
@@ -686,4 +689,15 @@ function isFineGrainedPAT(token) {
 function isClassicPAT(token) {
   const pattern = /^ghp_[a-zA-Z0-9]{36}$/;
   return token.match(pattern) != null;
+}
+
+// Inserts a blank line after every paragraph.
+// Note that innerHTML removes tags but not text even if it is white
+// space.
+
+function htmlToText(html) {
+  const html2 = html.replace(/<\/p[\s]*>/g, "</p>\n\n");
+  const temp = document.createElement("div");
+  temp.innerHTML = html2;
+  return temp.innerText;
 }

--- a/server/fishtest/templates/base.mak
+++ b/server/fishtest/templates/base.mak
@@ -171,13 +171,13 @@
                     function updatePullRequestIcon() {
                       const PR = new PullRequest();
                       PR.load();
-                      if(PR.getRunIds().length != 0){
+                      if(PR.body.trim() != ""){
 	                pullRequestIcon.style.color = "red";
 	              } else {
 	                pullRequestIcon.style.color = "";
 	              }
                     }
-                    document.addEventListener("visibilitychange", async () => {
+                    document.addEventListener("visibilitychange", () => {
                       updatePullRequestIcon();
                     });
                     updatePullRequestIcon();

--- a/server/fishtest/templates/pull_request.mak
+++ b/server/fishtest/templates/pull_request.mak
@@ -11,7 +11,7 @@
     <button class="nav-link" id="edit-tab" data-bs-toggle="tab" data-bs-target="#edit" type="button" role="tab" aria-controls="edit" aria-selected="false">Edit</button>
   </li>
   <li class="nav-item" role="presentation">
-    <button class="nav-link active" id="pull-request-tab" data-bs-toggle="tab" data-bs-target="#preview" type="button" role="tab" aria-controls="preview" aria-selected="true">Pull request</button>
+    <button class="nav-link active" id="pull-request-tab" data-bs-toggle="tab" data-bs-target="#pull-request" type="button" role="tab" aria-controls="pull-request" aria-selected="true">Pull request</button>
   </li>
   <li class="nav-item" role="presentation">
     <button class="nav-link" id="branch-tab" data-bs-toggle="tab" data-bs-target="#branch" type="button" role="tab" aria-controls="branch" aria-selected="false">Branch</button>
@@ -34,7 +34,7 @@
       <button id="clear" type="button" class="btn btn-secondary">Clear</button>
     </form>
   </div>
-  <div class="tab-pane fade show active" id="preview" role="tabpanel" aria-labelledby="pull-request-tab">
+  <div class="tab-pane fade show active" id="pull-request" role="tabpanel" aria-labelledby="pull-request-tab">
     <h5 class="pt-4">Pull request title</h5>
     <div id="rendered-title">
     </div>
@@ -77,11 +77,11 @@
     <form class="pt-4">
       <div class="mb-3">
          <label for="src-user" class ="form-label">Pull repo owner</label>
-         <input type="text" class="form-control" id="src-user" placeholder="Will be determined from tests">
+         <input type="text" class="form-control" id="src-user">
       </div>
       <div class="mb-3">
          <label for="src-repo" class ="form-label">Pull repo</label>
-         <input type="text" class="form-control" id="src-repo" placeholder="Will be determined from tests">
+         <input type="text" class="form-control" id="src-repo">
       </div>
       <div class="mb-3">
          <label for="src-branch" class ="form-label">Pull branch</label>
@@ -89,50 +89,58 @@
       </div>
       <div class="mb-3">
          <label for="dst-user" class ="form-label">Push user</label>
-         <input type="text" class="form-control" id="dst-user" placeholder="Set to official-stockfish, except when testing">
+         <input type="text" class="form-control" id="dst-user">
       </div>
       <div class="mb-3">
          <label for="dst-repo" class ="form-label">Push repo</label>
-         <input type="text" class="form-control" id="dst-repo" placeholder="Set to Stockfish, except when testing">
+         <input type="text" class="form-control" id="dst-repo">
       </div>
     </form>
   </div>
 </div>
 <script>
-  const pullRequestSrcUser = "${src_user|n}";
-  const pullRequestSrcRepo = "${src_repo|n}";
+  pullRequestDevUser = "${src_user|n}";
+  pullRequestDevRepo = "${src_repo|n}";
   (async () => {
       await DOMContentLoaded();
+
+      // edit
+      const editTab = document.getElementById("edit-tab");
       const titleElt = document.getElementById("title");
       const bodyElt = document.getElementById("body");
+      const clearBtn = document.getElementById("clear");
+
+      // pull request
+      const pullRequestTab = document.getElementById("pull-request-tab");
       const renderedPR = document.getElementById("rendered-pr");
       const renderedTitle = document.getElementById("rendered-title");
-      const commitMessage = document.getElementById("commit-message");
-      const pullRequestTab = document.getElementById("pull-request-tab");
-      const editTab = document.getElementById("edit-tab");
+      const submitBtn = document.getElementById("submit");
+      const copyBtn = document.getElementById("copy");
+      const openGitHubBtn = document.getElementById("open-github");
 
+      // branch
+      const branchTab = document.getElementById("branch-tab");
+      const branchName = document.getElementById("branch-name");
+      const checklistTable = document.getElementById("checklist-table");
+      const branchIsRebasedAndSquashedField = document.getElementById("rebased-and-squashed");
+      const commitIsPRField = document.getElementById("commit-is-pr");
+      const commitMessage = document.getElementById("commit-message");
+
+      // advanced
+      const advancedTab = document.getElementById("advanced-tab");
       const srcUser = document.getElementById("src-user");
       const srcRepo = document.getElementById("src-repo");
       const srcBranch = document.getElementById("src-branch");
       const dstUser = document.getElementById("dst-user");
       const dstRepo = document.getElementById("dst-repo");
 
-      const branchTab = document.getElementById("branch-tab");
-      const submitBtn = document.getElementById("submit");
-      const clearBtn = document.getElementById("clear");
-      const copyBtn = document.getElementById("copy");
-      const openGitHubBtn = document.getElementById("open-github");
+      srcUser.placeholder = pullRequestDevUser + " (obtained from profile)";
+      srcRepo.placeholder = pullRequestDevRepo + " (obtained from profile)";
+      dstUser.placeholder = "official-stockfish";
+      dstRepo.placeholder = "Stockfish";
 
-      const branchName = document.getElementById("branch-name");
+      const token = localStorage.getItem("github_token") ?? "";
 
-      const checklistTable = document.getElementById("checklist-table");
-      const branchIsRebasedAndSquashedField = document.getElementById("rebased-and-squashed");
-      const commitIsPRField = document.getElementById("commit-is-pr");
-
-      let token = localStorage.getItem("github_token");
-      if (!token) {
-        token = "";
-      }
       const PR = new PullRequest();
       PR.load();
       titleElt.value=PR.title;
@@ -140,23 +148,14 @@
       srcUser.value=PR.srcUser;
       srcRepo.value=PR.srcRepo;
       srcBranch.value=PR.srcBranch;
-      PR.dstUser = PR.dstUser || "official-stockfish";
-      PR.dstRepo = PR.dstRepo || "Stockfish";
-      PR.save();
       dstUser.value=PR.dstUser;
       dstRepo.value=PR.dstRepo;
-      function prLink(number) {
-        return "https://github.com/" + PR.dstUser + "/"+ PR.dstRepo +"/pull/" + number;
-      }
-      // updates button state, icon,
-      // but not pane with PR message and not check list
-      async function updateGUI(){
-        updatePullRequestIcon();
+
+      async function updatePullRequestTab() {
+        pullRequestTab.innerHTML = '<i class="fa fa-spinner fa-spin" aria-hidden="true"></i> Pull request';
         try {
-	  if(dstUser.value.trim() === "" || dstRepo.value.trim() === "") {
-	    throw new Error("Please specify the destination user/repo on the advanced tab and then refresh this page");
-	  }
-          const userData = await PR.getUserData();
+          renderedPR.innerHTML = await PR.renderBody(token);
+          renderedTitle.innerHTML= await PR.renderTitle(token);
           const number = await PR.getNumber(token);
           if(number){
             submitBtn.textContent="Update PR";
@@ -166,26 +165,31 @@
             openGitHubBtn.hidden = true;
           }
         } catch(e) {
-          const text = await processError(e);
-          alertError(text);
-          console.error(text);
+          console.error(e);
+          const error = await processError(e);
+          alertError(error);
+          renderedPR.innerHTML = "";
+          renderedTitle.innerHTML= "";
+          openGitHubBtn.hidden = true;
         }
+        pullRequestTab.innerHTML = 'Pull request';
       }
-      // updates branch tab and preview tab
+
       async function updateBranchTab() {
+        branchTab.innerHTML = '<i class="fa fa-spinner fa-spin" aria-hidden="true"></i> Branch';
         checklistTable.hidden = false;
         let branchClean = true;
         try {
           const userData = await PR.getUserData();
           if (!userData.branch) {
-            let message = "Could not determine pull user/branch.<br>";
-            message += "If you know what you are doing then you can specify them ";
-            message += "in the branch tab.";
+            let message = "Could not determine branch.<br>";
+            message += "If you know what you are doing then you can specify it ";
+            message += "in the advanced tab.";
             throw new Error(message);
           }
           branchName.innerHTML = await PR.branchLink();
           const commit = await PR.getCommit(token);
-          commitMessage.innerHTML = await commit.commit.message;
+          commitMessage.innerHTML = commit.commit.message;
           const branchIsRebasedAndSquashed = await PR.branchIsRebasedAndSquashed(token);
           if (branchIsRebasedAndSquashed) {
             branchIsRebasedAndSquashedField.innerHTML = "&check;";
@@ -195,12 +199,9 @@
             branchIsRebasedAndSquashedField.style.color = "red";
             branchClean = false;
           }
-          const message = removeBlankLines(commit.commit.message);
-          await updatePreview();
-          // There is something funky with innerText and white space
-          // on hidden DOM elements
-          // https://www.reddit.com/r/learnjavascript/comments/kjnixc/display_none_seems_to_remove_line_breaks_in_text/
-          const prText_ = removeBlankLines(prText());
+
+          const message = normalizeText(commit.commit.message);
+          const prText_ = normalizeText(await prText());
           const commitIsPR = prText_ === message;
           if (commitIsPR) {
             commitIsPRField.innerHTML = "&check;";
@@ -219,150 +220,132 @@
           commitMessage.innerHTML = "";
           branchClean = false;
         }
+        branchTab.innerHTML = 'Branch';
         return branchClean;
       }
-      // updates the tab with the PR message
-      async function updatePreview() {
-          try {
-            renderedPR.innerHTML = await PR.renderBody(token);
-            renderedTitle.innerHTML= await PR.renderTitle(token);
-            const userData = await PR.getUserData();
-          } catch(e) {
-            console.error(e);
-            const error = await processError(e);
-            alertError(error);
-            renderedPR.innerHTML = "";
-            renderedTitle.innerHTML= "";
-         }
-      }
-      await updateGUI();
-      await updatePreview();
-      actOnInput([titleElt, bodyElt, srcUser, srcRepo, srcBranch, dstUser, dstRepo], async () => {
-        PR.title = titleElt.value;
-        PR.body = bodyElt.value;
-        PR.srcUser = srcUser.value
-        PR.srcRepo = srcRepo.value
-        PR.srcBranch=srcBranch.value;
-        PR.dstUser=dstUser.value;
-        PR.dstRepo=dstRepo.value;
-        PR.save();
-      });
 
-      pullRequestTab.addEventListener("shown.bs.tab", async () => {
-	  await updatePreview();
-      });
       branchTab.addEventListener("shown.bs.tab", async () => {
 	  await updateBranchTab();
       });
-      clearBtn.addEventListener("click", async () => {
-          submitBtn.textContent="Create PR";
-          openGitHubBtn.hidden = true;
-          // Preserve undo history.
-          // This method is officially deprecated but widely
-          // supported according to MDN, and there is no
-          // alternative yet.
-          titleElt.select();
-          document.execCommand("insertText", false, "");
-          titleElt.blur();
-          bodyElt.select();
-          document.execCommand("insertText", false, "");
-          bodyElt.blur();
-          renderedPR.innerHTML="";
-          renderedTitle.innerHTML="";
-          PR.clear();
-          PR.save();
+
+      pullRequestTab.addEventListener("shown.bs.tab", async () => {
+	  await updatePullRequestTab();
       });
-      function prText() {
-        return normalizeText(renderedTitle.innerText.trimEnd() + "\n\n" + renderedPR.innerText.trimEnd()+"\n");
+
+      actOnInput([titleElt, bodyElt, srcUser, srcRepo, srcBranch, dstUser, dstRepo], async () => {
+        PR.title = titleElt.value; // internally escaped
+        PR.body = bodyElt.value; // internally rendered
+        PR.srcUser = escapeHtml(srcUser.value);
+        PR.srcRepo = escapeHtml(srcRepo.value);
+        PR.srcBranch = escapeHtml(srcBranch.value);
+        PR.dstUser = escapeHtml(dstUser.value);
+        PR.dstRepo = escapeHtml(dstRepo.value);
+        PR.save();
+        updatePullRequestIcon();
+      });
+
+      clearBtn.addEventListener("click", async () => {
+        submitBtn.textContent="Create PR";
+        // Preserve undo history.
+        // This method is officially deprecated but widely
+        // supported according to MDN, and there is no
+        // alternative yet.
+        titleElt.select();
+        document.execCommand("insertText", false, "");
+        titleElt.blur();
+        bodyElt.select();
+        document.execCommand("insertText", false, "");
+        bodyElt.blur();
+        PR.clear();
+        PR.save();
+        updatePullRequestIcon();
+      });
+
+      async function prText() {
+         return normalizeText(htmlToText(await PR.renderTitle())+"\n\n"+ htmlToText(await PR.renderBody()));
       }
-      copyBtn.addEventListener("click", () => {
-        navigator.clipboard.writeText(prText());
+      copyBtn.addEventListener("click", async () => {
+        navigator.clipboard.writeText(await prText());
         alertMessage("Copied to clipboard!");
       });
+
       submitBtn.addEventListener("click", async () => {
-	  try {
-              await validateToken(token);
-              const userData = await PR.getUserData();
-              let message = "You are about to " + (submitBtn.textContent.split(" ")[0]).toLowerCase()
-              message += " a pull request to "+ PR.dstUser+"/"+ PR.dstRepo+". Please confirm!";
-              let confirm1 = true;
-              let confirm2 = true;
-              let confirm3 = true;
-              let confirm4 = true;
-	      let confirm5 = true;
-              const confirm0 = confirm(message);
-              if (confirm0) {
-                if (userData.nonUniqueBranch) {
-                  confirm1 = confirm("The tests refer to more than one branch. Continue with submission?");
-                }
-                if (confirm1) {
-                  const cleanBranch = await updateBranchTab();
-	          if(!cleanBranch) {
-	            confirm2 = confirm("The branch is not clean (see the branch tab). Continue with submission?");
-	          }
-	          if (confirm2) {
-	            if (PR.srcBranch) {
-                      confirm3 = confirm("This PR has a manually supplied pull branch (see the advanced tab). Continue with submission?");
-	            }
-		    if (confirm3) {
-		      if (!userData.runCount) {
-                        confirm4 = confirm("This PR does not refer to any tests. Continue with submission?");
-                      }
-                      if (confirm4) {
-                        if (userData.user != pullRequestSrcUser) {
-                          confirm5 = confirm('The source user "' + userData.user + '" is different from the DEV user "' + pullRequestSrcUser + '". Continue with submission?');
-                        }
-                        if(confirm5) {
-                          const number = await PR.submit(token);
-                          submitBtn.textContent="Update PR";
-                          const message = "Submission of PR#" + number + " was successful! ";
-                          alertMessage(message);
-                          openGitHubBtn.hidden = false;
-                        }
-                      }
+        try {
+          await validateToken(token);
+          const userData = await PR.getUserData();
+          let confirm1 = true;
+          let confirm2 = true;
+          let confirm3 = true;
+          let confirm4 = true;
+          let confirm5 = true;
+
+          let message = "You are about to " + (submitBtn.textContent.split(" ")[0]).toLowerCase()
+          message += " a pull request to "+ userData.dstUser+"/"+ userData.dstRepo+". Please confirm!";
+
+          const confirm0 = confirm(message);
+          if (confirm0) {
+            if (userData.nonUniqueBranch) {
+              confirm1 = confirm("The tests refer to more than one branch. Continue with submission?");
+            }
+            if (confirm1) {
+              const cleanBranch = await updateBranchTab();
+              if(!cleanBranch) {
+	        confirm2 = confirm("The branch is not clean (see the branch tab). Continue with submission?");
+	      }
+	      if (confirm2) {
+	        if (PR.srcBranch) {
+                  confirm3 = confirm("This PR has a manually supplied pull branch (see the advanced tab). Continue with submission?");
+	        }
+                if (confirm3) {
+                  if (!userData.runCount) {
+                    confirm4 = confirm("This PR does not refer to any tests. Continue with submission?");
+                  }
+                  if (confirm4) {
+                    if (userData.user != pullRequestDevUser) {
+                      confirm5 = confirm('The source user "' + userData.user + '" is different from the DEV user "' + pullRequestDevUser + '". Continue with submission?');
+                    }
+                    if(confirm5) {
+                      const number = await PR.submit(token);
+                      submitBtn.textContent="Update PR";
+                      const message = "Submission of PR#" + number + " was successful! ";
+                      alertMessage(message);
+                      openGitHubBtn.hidden = false;
                     }
                   }
                 }
               }
-           } catch(e) {
-              console.error(e);
-              const error = await processError(e);
-              alertError(error);
-           }
+            }
+          }
+        } catch(e) {
+          console.error(e);
+          const error = await processError(e);
+          alertError(error);
+        }
       });
+
       openGitHubBtn.addEventListener("click", async () => {
         const number = await PR.getNumber();
-	if(number) {
-	  window.open(prLink(number), "github");
+        if(number) {
+          window.open((await PR.prLink(number)), "github");
 	}
       });
-      dstUser.addEventListener("blur", () => {
-        dstUser.value = PR.dstUser || "official-stockfish";
-      });
-      dstRepo.addEventListener("blur", () => {
-        dstRepo.value = PR.dstRepo || "Stockfish";
-      });
+
       document.addEventListener("visibilitychange", async () => {
-	  if(!document.hidden) {
-            PR.load();
-            titleElt.value = PR.title;
-            bodyElt.value = PR.body;
-            srcUser.value = PR.srcUser;
-            srcRepo.value = PR.srcRepo;
-            srcBranch.value=PR.srcBranch;
-            dstUser.value=PR.dstUser || "official-stockfish";
-            dstRepo.value=PR.dstRepo || "Stockfish";
-            await updatePreview();
-            await updateGUI();
-	  }
+        if(!document.hidden) {
+          PR.load();
+          titleElt.value = PR.title;
+          bodyElt.value = PR.body;
+          srcUser.value = PR.srcUser;
+          srcRepo.value = PR.srcRepo;
+          srcBranch.value = PR.srcBranch;
+          dstUser.value = PR.dstUser;
+          dstRepo.value = PR.dstRepo;
+          await updatePullRequestTab();
+          await updateBranchTab();
+        }
       });
-      document.addEventListener("runidschange", async (event) => {
-        if (event.detail.PR === PR) {
-          // The icon update uses a different PR object
-          PR.save();
-          await updateGUI();
-	}
-      });
-  })();
+
+      await updatePullRequestTab();
+    })();
 </script>
 


### PR DESCRIPTION
Cleanup/refactoring, tabs vs spaces.

Make srcUser and srcRepo equal to devUser and devRepo if unknown.

Make unknown dstUser/dstRepo equal to official-stockfish/Stockfish

Put in appropriate placeholders.

Make icon red when body is non-empty (except for space)

Remove some redudant placeholder strings.

Introduce some wait cursors.

Do not add notes to results.

Use a ChatGPT provided htmlToText()