### PR TITLE
Use run_id/task_id in the name of the pgn file

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -36,7 +36,7 @@ Proper configuration of `nginx` is crucial for this, and should be done
 according to the route/URL mapping defined in `__init__.py`.
 """
 
-WORKER_VERSION = 291
+WORKER_VERSION = 292
 
 
 @exception_view_config(HTTPException)

--- a/worker/games.py
+++ b/worker/games.py
@@ -165,7 +165,7 @@ def trim_files(testing_dir, source_dir=None):
         ("stockfish-*-old" + EXE_SUFFIX, 0, -1, True),
         ("stockfish-*" + EXE_SUFFIX, 50, 30, False),
         ("nn-*.nnue", 10, 30, False),
-        ("results-*.pgn", 0, -1, True),
+        ("results-*.pgn", 0, -1, False),
         ("*.epd", 4, 365, False),
         ("*.pgn", 4, 365, False),
     )
@@ -1503,13 +1503,9 @@ def run_games(
         establish_validated_net(remote, testing_dir, net, global_cache)
 
     # PGN files output setup.
-    pgn_name = "results-" + worker_info["unique_key"] + ".pgn"
+    pgn_name = f"results-{run['_id']}-{task_id}.pgn"
     pgn_file["name"] = testing_dir / pgn_name
     pgn_file["CRC"] = None
-    try:
-        pgn_file["name"].unlink()
-    except FileNotFoundError:
-        pass
 
     # Verify that the signatures are correct.
     run_errors = []

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 291, "updater.py": "eDDBPKA/vrTCadgtEJFdL06vSoiysF0JhiHKdEnjQv3zS4kfdOAqnco/DJpDWbvh", "worker.py": "d1w5yok7lUlT3bzLULAEIU9VSQ9GUiLbHRQNFEiW5QeKC5GL6Jvctd1xJ8SMrXIV", "games.py": "GjU/+wm0eGC8ZHz8D3xEUK7T/Los+NrLenqH7m0m3qC2kY6I7f0v7krm5BiHCDUR"}
+{"__version": 292, "updater.py": "eDDBPKA/vrTCadgtEJFdL06vSoiysF0JhiHKdEnjQv3zS4kfdOAqnco/DJpDWbvh", "worker.py": "XMuWlJNikm2DImolSK1y9aNZxy/r3cBH/kqRAxe94RDL05EZdnmR7u9iCeA/GfcE", "games.py": "FnnHEuh1g89aNWnI7BoOr/3kbFUJLagZDmq4vbjl8IBkZQDI/yhSUdpyxPCcTt9I"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -73,7 +73,7 @@ MIN_CLANG_MINOR = 0
 
 FASTCHESS_SHA = "66cac47f06dc1a09d3d1865cdbf560a7814f82ea"
 
-WORKER_VERSION = 291
+WORKER_VERSION = 292
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0
@@ -1411,11 +1411,6 @@ def fetch_and_handle_task(
                 upload_pgn_data(data, run["_id"], task_id, remote, payload)
         except Exception as e:
             print(f"\nException uploading PGN file:\n{e}", file=sys.stderr)
-
-    try:
-        pgn_file.unlink()
-    except Exception as e:
-        print(f"Exception deleting PGN file:\n{e}", file=sys.stderr)
 
     print("Task exited.")
     return success


### PR DESCRIPTION
This should fix #2385 (the cause of that issue remains unclear however).

Note: we no longer delete the pgn file. We rely instead on the trim_files() function which is called when starting a new task.