### PR TITLE
Let fish.finish gracefully stop the worker

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -18,7 +18,7 @@ from fishtest.schemas import api_access_schema, api_schema, gzip_data
 from fishtest.stats.stat_util import SPRT_elo, get_elo
 from fishtest.util import strip_run, worker_name
 
-WORKER_VERSION = 322
+WORKER_VERSION = 323
 
 WORKER_API_PATHS = {
     "/api/request_version",

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 322, "updater.py": "sUFX8k5Cb1k3f2Vpp6i1XmIJpYJ9+1U1H/4GDyWiLOnyN6/OxPOJSirPu6CnkPOb", "worker.py": "4pk3QIV0NKlU4L0fbAcwrwapMUeZTqRCQjwty8nRNLc90VtVwQbL84Y1wcoBDv48", "games.py": "PZ5t74yJuStxJP5m26Tk/iYRsvFZogXSbJmyyHhfu68/c4+x/GTDTnIdC1dfp7VG"}
+{"__version": 323, "updater.py": "sUFX8k5Cb1k3f2Vpp6i1XmIJpYJ9+1U1H/4GDyWiLOnyN6/OxPOJSirPu6CnkPOb", "worker.py": "vLhXtKf1vzPrrQey4xrFY8M6DPxPTyQ4I5QgJFJT/RSbfzHH18ZzgrBZEw1lmA1f", "games.py": "PZ5t74yJuStxJP5m26Tk/iYRsvFZogXSbJmyyHhfu68/c4+x/GTDTnIdC1dfp7VG"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -74,7 +74,7 @@ MIN_CLANG_MINOR = 0
 
 FASTCHESS_SHA = "3de44228aec904e688a4ad71c554eb9d461a5a2a"
 
-WORKER_VERSION = 322
+WORKER_VERSION = 323
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0
@@ -1609,6 +1609,11 @@ def worker():
     fish_exit = False
 
     while current_state["alive"]:
+        if (worker_dir / "fish.finish").is_file():
+            current_state["alive"] = False
+            print("Stopped by 'fish.finish' file")
+            fish_exit = True
+            break
         success = fetch_and_handle_task(
             worker_dir,
             worker_info,
@@ -1638,8 +1643,10 @@ def worker():
             delay = INITIAL_RETRY_TIME
 
     if fish_exit:
-        print("Removing fish.exit file.")
-        (worker_dir / "fish.exit").unlink()
+        print("Removing 'fish.[exit|finish]' file(s).")
+        for filename in ["fish.exit", "fish.finish"]:
+            if (worker_dir / filename).is_file():
+                (worker_dir / filename).unlink()
 
     print("Releasing the worker lock.")
     worker_lock.release()


### PR DESCRIPTION
Ever since #2163 there is no longer a way to truly gracefully stop the worker, as evidenced by the [Event log](https://tests.stockfishchess.org/actions?text=%22fish.exit%22). This also contradicts our [docs](https://github.com/official-stockfish/fishtest/wiki/Running-the-Worker#stop-the-worker).

Recall that before #2163 the presence of `fish.exit` in the worker directory meant the worker would finish the assigned task and then stop. Since #2163 the worker will wait for the next game pair to finish, and then send the stats and pgn of the games finished so far to the server and stop, irrespective of how many games are currently still running on the machine, and how many games are left to complete for the task.

This PR proposes to let the file `fish.finish` play the old role of `fish.exit`. I am happy to update the docs to reflect the new situation if and when this gets merged. Notice that also our [docker](https://github.com/official-stockfish/docker-fishtest/blob/f766dd26caa6f56ade8a5ba669b1a9e2112378b8/worker/updater.sh#L23-L29) appears to rely on the old implementation. (At least docs and code comments suggest that.) I would propose to migrate these to `fish.finish` if this PR gets merged.

With this PR there are at least four ways to stop the worker:
* CTRL-C (immediate stop, kills all running games, does not send stats update to server)
* `kill -15 pid` (as above)
* `touch fish.exit` (near immediate stop, sends update to server, kills nearly all running games, raises exception)
* `touch fish.finish` (graceful stop, may take time to take effect)