### PR TITLE
Two cleanups

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -936,6 +936,7 @@ class RunDb:
         return machines
 
     def aggregate_unfinished_runs(self, username=None):
+        # The global stats are computed for the homepage, i.e. when username is Falsy, and are 0 otherwise
         unfinished_runs = self.get_unfinished_runs(username=username)
         runs = {"pending": [], "active": []}
         for run in unfinished_runs:
@@ -963,17 +964,18 @@ class RunDb:
         machines_count = 0
         nps = 0.0
         games_per_minute = 0.0
-        for run in runs["active"]:
-            machines_count += run["workers"]
-            cores += run["cores"]
-            nps += run.get("nps", 0.0)
-            games_per_minute += run.get("games_per_minute", 0.0)
-
         pending_hours = 0
-        for run in runs["pending"] + runs["active"]:
+        if not username:  # Only the homepage gets global stats
+            for run in runs["active"]:
+                machines_count += run["workers"]
+                cores += run["cores"]
+                nps += run.get("nps", 0.0)
+                games_per_minute += run.get("games_per_minute", 0.0)
             if cores > 0:
-                eta = remaining_hours(run) / cores
-                pending_hours += eta
+                for run in runs["pending"] + runs["active"]:
+                    eta = remaining_hours(run) / cores
+                    pending_hours += eta
+
         return (
             runs,
             pending_hours,

--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -972,7 +972,7 @@ class RunDb:
                 nps += run.get("nps", 0.0)
                 games_per_minute += run.get("games_per_minute", 0.0)
             if cores > 0:
-                for run in runs["pending"] + runs["active"]:
+                for run in runs["active"]:
                     eta = remaining_hours(run) / cores
                     pending_hours += eta
 

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -2900,7 +2900,7 @@ def _build_tests_run_tables_fragment_context(
         "count_updates": count_updates,
     }
 
-    # workers-count target exists on homepage only.
+    # Homepage only: update the workers-count target and stats OOB
     if not username:
         filtered_count = (
             _filtered_machine_count(
@@ -2920,9 +2920,6 @@ def _build_tests_run_tables_fragment_context(
             filtered_count=filtered_count,
         )
         result["workers_count_text"] = workers_count
-
-    # Include stats OOB updates for the homepage (no username filter).
-    if not username:
         result["stats"] = {
             "pending_hours": f"{pending_hours:.1f}",
             "cores": cores,


### PR DESCRIPTION
This contains two commits with changes originally found/made while working on 2567. I've separated them out here as being nice improvements independent of the substance of opinions within 2567. (And perhaps merging these separately will reduce the diff over there, helping focus discussion...?)

The first commit fixes a minor thing spotted by Copilot, namely that global stats are only used on the homepage. It is a straightforward improvement to the codebase imo.

The second commit changes `pending_hours`, i.e. "Time remaining" on the homepage, to exclude paused tests, since they on average never resume. This commit is optional.