### PR TITLE
fix: make the SPRT Elo confidence bound model-invariant (issue 2571)

### DIFF
--- a/server/fishtest/stats/sprt.py
+++ b/server/fishtest/stats/sprt.py
@@ -10,6 +10,15 @@ from fishtest.stats.brownian import Brownian
 
 
 class sprt:
+    # Elo axis clamp for the confidence-bound search. outcome_prob maps Elo
+    # through the logistic score law, so the search runs in logistic Elo over
+    # [-CB_CLAMP, CB_CLAMP] regardless of the elo_model.
+    CB_CLAMP = 1000.0
+    # Grid step (Elo) for the coarse scan. The descending region of outcome_prob
+    # is tens to hundreds of Elo wide for real pentanomial data, so a 10 Elo grid
+    # cannot skip over the leftmost crossing; brentq then refines each bracket.
+    CB_STEP = 10.0
+
     def __init__(self, alpha=0.05, beta=0.05, elo0=0, elo1=5, elo_model="logistic"):
         assert elo_model in ("logistic", "normalized")
         self.elo_model = elo_model
@@ -80,45 +89,80 @@ class sprt:
             T=self.T, y=self.llr
         )
 
+    def _confidence_bounds(self, ps):
+        """
+        For each probability p in `ps`, return the maximal Elo such that the
+        observed outcome of the test has probability less than p, i.e. the Elo
+        where outcome_prob(elo) == 1 - p. The results align with `ps`.
+
+        The root is sought on the logistic Elo axis that outcome_prob uses
+        (s = L_(elo)), over the fixed window [-CB_CLAMP, CB_CLAMP]. The search
+        does not depend on the elo_model or on the units of the SPRT bounds, so
+        every caller and every elo_model agrees on the result.
+
+        outcome_prob is monotone decreasing in Elo only while the small-Elo GSPRT
+        approximation holds. Once the observed Elo lies far outside [elo0, elo1]
+        the approximation breaks down: outcome_prob dips to a minimum and rises
+        again toward the clamp. The confidence bound is the leftmost (descending)
+        crossing; the spurious rising branch is ignored. A level that is never
+        reached inside the window is pinned to the clamp and sets self.clamped.
+        """
+        lo, hi = -self.CB_CLAMP, self.CB_CLAMP
+        steps = round((hi - lo) / self.CB_STEP)
+        # outcome_prob level targeted by each requested p, and the bound for it
+        levels = [1 - p for p in ps]
+        bounds = [None] * len(ps)
+        op_prev = self.outcome_prob(lo)
+        pending = []
+        for index, level in enumerate(levels):
+            if op_prev <= level:
+                # the crossing is at or below the low clamp
+                bounds[index] = lo
+                self.clamped = True
+            else:
+                pending.append(index)
+        x_prev = lo
+        for step in range(1, steps + 1):
+            if not pending:
+                break
+            x = lo + (hi - lo) * step / steps
+            op = self.outcome_prob(x)
+            still_pending = []
+            for index in pending:
+                level = levels[index]
+                # leftmost descending crossing of `level` in (x_prev, x]
+                if op_prev >= level > op:
+                    bounds[index] = scipy.optimize.brentq(
+                        lambda elo, level=level: self.outcome_prob(elo) - level,
+                        x_prev,
+                        x,
+                        disp=False,
+                    )
+                else:
+                    still_pending.append(index)
+            pending = still_pending
+            x_prev, op_prev = x, op
+        for index in pending:
+            # never reached inside the window: the bound is unbounded above
+            bounds[index] = hi
+            self.clamped = True
+        return bounds
+
     def lower_cb(self, p):
         """
-        Maximal elo value such that the observed outcome of the test has probability
-        less than p."""
-        avg_elo = (self.elo0 + self.elo1) / 2
-        delta = self.elo1 - self.elo0
-        N = 30
-        # Various error conditions must be handled better here!
-        while True:
-            elo0 = max(avg_elo - N * delta, -1000)
-            elo1 = min(avg_elo + N * delta, 1000)
-            try:
-                sol, res = scipy.optimize.brentq(
-                    lambda elo: self.outcome_prob(elo) - (1 - p),
-                    elo0,
-                    elo1,
-                    full_output=True,
-                    disp=False,
-                )
-            except ValueError:
-                if elo0 > -1000 or elo1 < 1000:
-                    N *= 2
-                    continue
-                else:
-                    if self.outcome_prob(elo0) - (1 - p) > 0:
-                        return elo1
-                    else:
-                        return elo0
-            assert res.converged
-            break
-        return sol
+        Maximal Elo value such that the observed outcome of the test has
+        probability less than p."""
+        (bound,) = self._confidence_bounds([p])
+        return bound
 
     def analytics(self, p=0.05):
+        elo, ci_lower, ci_upper = self._confidence_bounds([0.5, p / 2, 1 - p / 2])
         ret = {}
         ret["clamped"] = self.clamped
         ret["a"] = self.a
         ret["b"] = self.b
-        ret["elo"] = self.lower_cb(0.5)
-        ret["ci"] = [self.lower_cb(p / 2), self.lower_cb(1 - p / 2)]
+        ret["elo"] = elo
+        ret["ci"] = [ci_lower, ci_upper]
         ret["LOS"] = self.outcome_prob(0)
         ret["LLR"] = self.llr
         return ret

--- a/server/tests/test_stats_sprt.py
+++ b/server/tests/test_stats_sprt.py
@@ -1,0 +1,121 @@
+"""Confidence-bound inversion in `fishtest.stats.sprt` (issue 2571).
+
+The live Elo page and the raw statistics page build the SPRT object in different
+Elo models (normalized vs logistic) and used to disagree on the Elo estimate and
+its confidence interval: one page showed a bare 1000, the other a finite value.
+These tests pin the fixed behavior: the confidence bound is model-invariant, the
+well-posed values are preserved, ordering holds, and a genuinely unbounded bound
+pins to the clamp.
+"""
+
+import unittest
+
+from fishtest.stats import LLRcalc
+from fishtest.stats import stat_util as su
+from fishtest.stats.sprt import sprt
+
+# Reuse the estimator's own clamp constant instead of hard-coding it.
+CLAMP = sprt.CB_CLAMP
+
+
+def _pent_sigma(pentanomial):
+    """Per-game stdev of the pentanomial, as the stats page computes it."""
+    _, pdf = LLRcalc.results_to_pdf(pentanomial)
+    _, var = LLRcalc.stats(pdf)
+    return (2 * var) ** 0.5
+
+
+def _analytics(pentanomial, model, elo0=0.0, elo1=2.0):
+    """Reproduce how each page parameterizes the SPRT object.
+
+    The live Elo page keeps the run's native normalized bounds; the stats page
+    converts the bounds to logistic Elo through the pentanomial score. Both feed
+    the same pentanomial, so a correct estimator must return the same analytics.
+    """
+    results = LLRcalc.regularize(pentanomial)
+    if model == "normalized":
+        sp = sprt(alpha=0.05, beta=0.05, elo0=elo0, elo1=elo1, elo_model="normalized")
+    elif model == "logistic":
+        sigma = _pent_sigma(pentanomial)
+        ndbnt = LLRcalc.nelo_divided_by_nt
+        lelo0 = su.elo(elo0 / ndbnt * sigma + 0.5)
+        lelo1 = su.elo(elo1 / ndbnt * sigma + 0.5)
+        sp = sprt(alpha=0.05, beta=0.05, elo0=lelo0, elo1=lelo1, elo_model="logistic")
+    else:
+        raise AssertionError(model)
+    sp.set_state(results)
+    return sp.analytics()
+
+
+# The pentanomial reported in issue 2571: a strongly passing test whose observed
+# Elo lies far outside the SPRT bounds, so outcome_prob is non-monotone.
+ISSUE_PENT = [1, 20, 300, 900, 779]
+
+# A spread of well-posed passing tests.
+WELL_POSED = [
+    [1, 60, 500, 1200, 500],
+    [1, 60, 500, 1200, 600],
+    [1, 60, 500, 1200, 700],
+]
+
+
+class ConfidenceBoundTest(unittest.TestCase):
+    def test_model_invariance_on_divergence_case(self):
+        # The exact case from issue 2571 must no longer depend on the Elo model:
+        # both pages report the same, finite estimate instead of 1000 vs finite.
+        norm = _analytics(ISSUE_PENT, "normalized")
+        logi = _analytics(ISSUE_PENT, "logistic")
+        self.assertAlmostEqual(norm["elo"], logi["elo"], places=6)
+        self.assertAlmostEqual(norm["ci"][0], logi["ci"][0], places=6)
+        self.assertAlmostEqual(norm["ci"][1], logi["ci"][1], places=6)
+        # finite: not the raw clamp
+        self.assertLess(norm["elo"], CLAMP)
+        self.assertLess(norm["ci"][1], CLAMP)
+        # pinned reference values (both models)
+        self.assertAlmostEqual(norm["elo"], 245.4729, places=3)
+        self.assertAlmostEqual(norm["ci"][0], 223.6370, places=3)
+        self.assertAlmostEqual(norm["ci"][1], 289.7981, places=3)
+
+    def test_well_posed_model_invariance(self):
+        for pent in WELL_POSED:
+            with self.subTest(pent=pent):
+                norm = _analytics(pent, "normalized")
+                logi = _analytics(pent, "logistic")
+                self.assertAlmostEqual(norm["elo"], logi["elo"], places=6)
+                self.assertAlmostEqual(norm["ci"][0], logi["ci"][0], places=6)
+                self.assertAlmostEqual(norm["ci"][1], logi["ci"][1], places=6)
+
+    def test_well_posed_reference_values(self):
+        # Regression guard: pin the estimator output on a stable well-posed case.
+        a = _analytics([1, 60, 500, 1200, 600], "normalized")
+        self.assertAlmostEqual(a["elo"], 188.3595, places=3)
+        self.assertAlmostEqual(a["ci"][0], 170.7252, places=3)
+        self.assertAlmostEqual(a["ci"][1], 214.8484, places=3)
+
+    def test_confidence_interval_is_ordered(self):
+        for pent in [ISSUE_PENT, *WELL_POSED]:
+            for model in ("normalized", "logistic"):
+                with self.subTest(pent=pent, model=model):
+                    a = _analytics(pent, model)
+                    self.assertLessEqual(a["ci"][0], a["elo"])
+                    self.assertLessEqual(a["elo"], a["ci"][1])
+
+    def test_unbounded_bound_pins_to_clamp(self):
+        # An off-scale test: outcome_prob never reaches the upper-CI level inside
+        # the window, so the upper bound pins to the clamp and clamped is set.
+        a = _analytics([0, 0, 1, 5, 994], "normalized")
+        self.assertEqual(a["ci"][1], CLAMP)
+        self.assertTrue(a["clamped"])
+
+    def test_lower_cb_matches_analytics(self):
+        # The public single-target wrapper agrees with the shared-scan analytics.
+        sp = sprt(alpha=0.05, beta=0.05, elo0=0.0, elo1=2.0, elo_model="normalized")
+        sp.set_state(LLRcalc.regularize(ISSUE_PENT))
+        a = sp.analytics()
+        self.assertAlmostEqual(sp.lower_cb(0.5), a["elo"], places=6)
+        self.assertAlmostEqual(sp.lower_cb(0.025), a["ci"][0], places=6)
+        self.assertAlmostEqual(sp.lower_cb(0.975), a["ci"][1], places=6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The live Elo page and the raw statistics page reported different Elo bounds for the same test: one showed a bare 1000, the other a finite value. Both pages call the same estimator, sprt.sprt.analytics, but built the SPRT object in different Elo models, and lower_cb inverted outcome_prob with a search window whose step size was the bound spread in those model units. outcome_prob maps Elo through the logistic score law, so the window unit had no statistical meaning. Past the SPRT range the LLR is clamped and outcome_prob stops being monotone, so whether brentq bracketed a finite root or fell through to the plus/minus 1000 clamp depended on the model-unit window schedule.

Search the confidence bound on the logistic Elo axis over a fixed window, independent of the SPRT bounds, and take the leftmost descending crossing so the meaningful bound is selected and the spurious rising branch past the SPRT range is ignored. A single shared grid scan brackets the point estimate and both confidence bounds, then brentq refines each; targets that are never reached inside the clamp window pin to the clamp and set the clamped flag. Both pages now report the same, well-defined estimate.

The estimator is display and reporting only and is not on the pass/fail path, so test outcomes are unaffected. Well-posed output is preserved to brentq tolerance. Add server/tests/test_stats_sprt.py covering well-posed parity, model invariance, the divergence reproduction, ordering, and clamp behavior.