### PR TITLE
Add % c column to SPSA parameter table

### DIFF
--- a/server/fishtest/spsa_workflow.py
+++ b/server/fishtest/spsa_workflow.py
@@ -455,6 +455,11 @@ def format_spsa_value(
         try:
             c_iter = param["c"] / (iter_local**gamma)
             r_iter = param["a"] / (A + iter_local) ** alpha / c_iter**2
+            pct_c = (
+                (param["theta"] - param["start"]) / c_iter * 100
+                if c_iter != 0
+                else float("nan")
+            )
         except (ArithmeticError, TypeError, ValueError) as error:
             if logger is not None and run_id is not None:
                 logger.warning(
@@ -467,10 +472,15 @@ def format_spsa_value(
                 )
             c_iter = float("nan")
             r_iter = float("nan")
+            pct_c = float("nan")
+
+        pct_c_str = f"{pct_c:+.1f}%" if isfinite(pct_c) else "N/A"
+        
         spsa_value.append(
             [
                 param["name"],
                 "{:.2f}".format(param["theta"]),
+                pct_c_str,
                 str(int(param["start"])),
                 str(int(param["min"])),
                 str(int(param["max"])),

--- a/server/fishtest/spsa_workflow.py
+++ b/server/fishtest/spsa_workflow.py
@@ -455,11 +455,7 @@ def format_spsa_value(
         try:
             c_iter = param["c"] / (iter_local**gamma)
             r_iter = param["a"] / (A + iter_local) ** alpha / c_iter**2
-            pct_c = (
-                (param["theta"] - param["start"]) / c_iter * 100
-                if c_iter != 0
-                else float("nan")
-            )
+            pct_c = (param["theta"] - param["start"]) / c_iter * 100
         except (ArithmeticError, TypeError, ValueError) as error:
             if logger is not None and run_id is not None:
                 logger.warning(
@@ -475,7 +471,7 @@ def format_spsa_value(
             pct_c = float("nan")
 
         pct_c_str = f"{pct_c:+.1f}%" if isfinite(pct_c) else "N/A"
-        
+
         spsa_value.append(
             [
                 param["name"],
@@ -490,7 +486,7 @@ def format_spsa_value(
                 "{:.2e}".format(param["r_end"]),
             ],
         )
-    return spsa_value
+        return spsa_value
 
 
 def build_spsa_worker_step(

--- a/server/fishtest/templates/tests_view_details_section.html.j2
+++ b/server/fishtest/templates/tests_view_details_section.html.j2
@@ -25,6 +25,7 @@
                       <tr>
                         <th>param</th>
                         <th>value</th>
+                        <th>% c</th>
                         <th>start</th>
                         <th>min</th>
                         <th>max</th>


### PR DESCRIPTION
This PR adds a % c column to the SPSA parameter table in the test details view (/tests/view/<id>).

Currently, the relative movement of an SPSA parameter (% c) is visualized in the SPSA kernel smoother chart, but it is not directly visible in the parameter table above it. Adding this column allows developers to quickly inspect the relative parameter shift alongside its raw value and initial start value without needing to navigate the graph.