### PR TITLE
Fix for issue 2571

### DIFF
--- a/server/fishtest/stats/LLRcalc.py
+++ b/server/fishtest/stats/LLRcalc.py
@@ -105,7 +105,7 @@ def MLE_t_value(pdfhat, ref, s):
 
 
 def stats(pdf):
-    epsilon = 1e-6
+    epsilon = 1e-3
     for i in range(0, len(pdf)):
         assert -epsilon <= pdf[i][1] <= 1 + epsilon
     n = sum([prob for value, prob in pdf])
@@ -180,11 +180,15 @@ def LLR_drift_variance(pdf, s0, s1, s=None):
     Compute the drift and variance of the LLR for a test s=s0 against
     s=s0 when the empirical distribution is pdf, but the true value of s
     is as given by the argument s. If s is not given then it is assumed
-    that pdf is the true distribution."""
-    if s is not None:
-        pdf = MLE_expected(pdf, s)
-    jumps = LLRjumps(pdf, s0, s1)
-    return stats(jumps)
+    that pdf is the true distribution. See
+
+    https://www.cantate.be/Fishtest/GSPRT_approximation.pdf
+    """
+    _, var_LLR = stats(LLRjumps(pdf, s0, s1))
+    if s is None:
+        s, _ = stats(pdf)
+    mu_LLR, _ = stats(LLRjumps(MLE_expected(pdf, s), s0, s1))
+    return mu_LLR, var_LLR
 
 
 def LLR_drift_variance_alt2(pdf, s0, s1, s=None):
@@ -192,14 +196,14 @@ def LLR_drift_variance_alt2(pdf, s0, s1, s=None):
     Compute the approximated drift and variance of the LLR for a test
     s=s0 against s=s0 approximated by a Brownian motion, when the
     empirical distribution is pdf, but the true value of s is as given by
-    the argument s. If s is not given the it is assumed that pdf is the
+    the argument s. If s is not given then it is assumed that pdf is the
     true distribution. See
 
     https://www.cantate.be/Fishtest/GSPRT_approximation.pdf
     """
-    s_, v_ = stats(pdf)
-    # replace v_ by its MLE if requested
-    s, v = (s_, v_) if s is None else (s, v_ + (s - s_) ** 2)
+    s_, v = stats(pdf)
+    if s is None:
+        s = s_
     mu = (s - (s0 + s1) / 2) * (s1 - s0) / v
     var = (s1 - s0) ** 2 / v
     return mu, var

--- a/server/fishtest/stats/sprt.py
+++ b/server/fishtest/stats/sprt.py
@@ -10,6 +10,14 @@ from fishtest.stats.brownian import Brownian
 
 
 class sprt:
+    """
+    This class allows one to compute median unbiased Elo estimates
+    for SPRT tests, as well as the corresponding confidence intervals.
+
+    IMPORTANT: The algorithms only work correctly for small Elo differences.
+    For large Elo differences the computed numbers only have a qualitative meaning.
+    """
+
     def __init__(self, alpha=0.05, beta=0.05, elo0=0, elo1=5, elo_model="logistic"):
         assert elo_model in ("logistic", "normalized")
         self.elo_model = elo_model


### PR DESCRIPTION
The algorithms in LLRcalc.py and sprt.py for computing a median unbiased Elo estimate from SPRT tests, as well as the corresponding confidence intervals, were never intended to work correctly for large Elo values. So issue 2571 is mainly cosmetic. Nonetheless one would prefer that the algorithms return something reasonable, even for large Elo values.

The root cause for issue 2571 is that outcome_prob (the probability of observing a result worse than the actual one, for a given drift) is not monotonous with the current code. This was correctly observed by the AI although the given reason was wrong.

The actual reason is that in the code for outcome_prob the infinitesimal variance of the Brownian approximation is estimated conditionally on the given value of the drift. While this is in principle correct, the resulting distribution cannot be used naively and in fact I don't know how to do it (we are not in the setting of Wilks' theorem for example). So in this PR we estimate the infinitesimal variance unconditionally and hope for the best. For small ELO values this makes no difference as the drift and the variance are orthogonal and it seems that with this change outcome_prob becomes monotonous in all cases.

The AI also observes that the clamp +- 1000 depends on the elo model (normalized or logistic). This is correct but harmless as long as we do not hit the clamp. I will fix this is in a separate PR.