### PR TITLE
fix(indexes): let finished_runs serve the unfiltered finished query

### DIFF
--- a/server/utils/create_indexes.py
+++ b/server/utils/create_indexes.py
@@ -28,10 +28,16 @@ def create_runs_indexes():
         name="unfinished_runs",
         partialFilterExpression={"finished": False},
     )
+    # Keep "deleted" out of the partial filter or queries omitting it cannot
+    # use this index; as a trailing key it still answers {"deleted": False}.
     db["runs"].create_index(
-        [("finished", ASCENDING), ("last_updated", DESCENDING)],
+        [
+            ("finished", ASCENDING),
+            ("last_updated", DESCENDING),
+            ("deleted", ASCENDING),
+        ],
         name="finished_runs",
-        partialFilterExpression={"finished": True, "deleted": False},
+        partialFilterExpression={"finished": True},
     )
     db["runs"].create_index(
         [


### PR DESCRIPTION
A partial index is only eligible for a query that implies its filter. 0f08ffaa added "deleted": false to the partialFilterExpression of finished_runs on 2026-03-09, which made the index unusable for every query that does not mention "deleted".

Two consumers do not mention it, both deliberately:

delta_update_users.py:199 walks all finished runs sorted by last_updated. Deleted runs must be counted there, because c09c1a5d removed the skip in 2019 on the grounds that the workers did run those games.

purge_pgns.py:18 queries {"finished", "deleted", "last_updated"} for both values of "deleted"; the deleted branch lost the index the same way.

Both had used the index for years under the filter {"finished": True}, and ran degraded for five months. Neither ever returned a wrong result or failed: what was lost is a query plan, not correctness.

Field observation, production mongod.log 2026-08-10 18:47: COLLSCAN, docsExamined 185785 for nreturned 44, a 27.5 GB sort spilling 5.6 GB to disk over 265 spills, 27.7 GB read from storage, 48.0 s of CPU.

Measured on the production data set, mongod 8.2.12, fishtest_new.runs, 185859 finished runs of which 17539 deleted and 0 without the field. explain("executionStats") consumes the whole cursor, so these times cover the full result set rather than the first batch of the logged query.

  find({finished: true}).sort({last_updated: -1})

                        before                  after
    plan                SORT <- COLLSCAN        FETCH <- IXSCAN
    executionTimeMillis 76279                   18254
    sort stage          75801 ms                none
    totalDataSizeSorted 27556661692             0
    usedDisk / spills   true / 265              none
    spilledDataStorage  5628822069              0
    totalKeysExamined   0                       185859
    totalDocsExamined   185896                  185859

  count({finished: true, deleted: false}, hint "finished_runs")

    plan                COUNT <- COUNT_SCAN     COUNT <- IXSCAN
    executionTimeMillis 85                      150
    keysExamined        168321                  185859
    docsExamined        0                       0
    nCounted            168320                  168320

docsExamined does not fall because 185859 of the 185896 documents are finished: the predicate is not selective and no index can reduce the scan. The index supplies the ordering, which is what removes the sort.

The count holds docsExamined at 0 only because "deleted" is a key: the planner builds bounds [false, false] on it and seeks past the 17539 deleted runs, 17540 seeks. Dropping "deleted" from the filter without adding the key makes the count fetch every document instead. Placing it before last_updated keeps COUNT_SCAN but cannot supply the sort, so the trailing position is the only one that serves both. Its price is 65 ms on the finished tests page count, against 58 s and 5.6 GB of disk spill removed from the stats walk.

The intent of 0f08ffaa is preserved. _build_finished_runs_query still emits {"finished": True, "deleted": False}, so deleted runs stay out of the finished tests page. The exclusion is enforced by the query predicate instead of by the index filter, where it also governed unrelated consumers. countDocuments on production is unchanged across the swap: 185859 finished, 168320 not deleted, 17539 deleted. Replaying the eleven runs-collection query shapes of the code base against the old and the new index on a test collection returns identical _id sets and counts.

Deployment: the index must be rebuilt for the fix to take effect. _find_finished_runs_rows drops the hint when the index name is missing, so code and index may be deployed in either order.

ruff check server/ and ruff format --check pass. pytest tests/ gives 545 passed with the same one failure and two collection errors present on the unmodified branch head, verified in a clean worktree.